### PR TITLE
Update error messages docs and tests

### DIFF
--- a/.vscode/custom-rules/sentence-case-heading.js
+++ b/.vscode/custom-rules/sentence-case-heading.js
@@ -45,10 +45,11 @@ function extractHeadingText(tokens, lines, token) {
   );
   if (seq) {
     const textStartColumn = seq.endColumn;
-    return lineText.substring(textStartColumn - 1, token.endColumn - 1).trim();
+    const text = lineText.substring(textStartColumn - 1, token.endColumn - 1);
+    return text.replace(/<!--.*-->/g, '').trim();
   }
   const match = lineText.match(/^#+\s*(.*)/);
-  return match && match[1] ? match[1].trim() : '';
+  return match && match[1] ? match[1].replace(/<!--.*-->/g, '').trim() : '';
 }
 
 /**

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -58,7 +58,9 @@ The rule provides specific error messages to help users understand the violation
 
 * "Heading's first word should be capitalized."
 * "Only the first letter of the first word in a heading should be capitalized (unless it's a short acronym)."
-* "Word "X" in heading should be lowercase."
+* "Word \"X\" in heading should be lowercase."
+* "Word \"X\" in heading should be capitalized."
+* "Single-word heading should be capitalized."
 * "Heading should not be in all caps."
 
 #### Implementation details

--- a/tests/sentence-case-heading.test.js
+++ b/tests/sentence-case-heading.test.js
@@ -158,6 +158,7 @@ describe("sentence-case-heading rule", () => {
       expect([
         "Heading's first word should be capitalized.",
         "Only the first letter of the first word in a heading should be capitalized (unless it's a short acronym).",
+        "Single-word heading should be capitalized.",
         /Word ".*" in heading should be lowercase./,
         /Word ".*" in heading should be capitalized./,
         "Heading should not be in all caps."
@@ -168,5 +169,11 @@ describe("sentence-case-heading rule", () => {
         return violation.errorDetail === pattern;
       })).toBe(true);
     });
+
+    const fixtureLines = fs.readFileSync(fixturePath, "utf8").split("\n");
+    const cssLine = fixtureLines.findIndex(line => line.startsWith("# css")) + 1;
+    const cssViolation = ruleViolations.find(v => v.lineNumber === cssLine);
+    expect(cssViolation).toBeTruthy();
+    expect(cssViolation.errorDetail).toBe("Single-word heading should be capitalized.");
   });
 });


### PR DESCRIPTION
## Summary
- document additional sentence-case-heading error messages
- ignore HTML comments in headings
- expect single-word heading error in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684120f3c1c4833395aa22306e4c04e2