### PR TITLE
Improve emoji handling in sentence-case rule

### DIFF
--- a/.vscode/custom-rules/sentence-case-heading.js
+++ b/.vscode/custom-rules/sentence-case-heading.js
@@ -109,6 +109,12 @@ function basicSentenceCaseHeadingFunction(params, onError) {
       return;
     }
 
+    // Strip leading emoji or symbol characters before analysis
+    headingText = headingText.replace(/^[\u{1F000}-\u{1FFFF}\u{2000}-\u{3FFF}]+\s*/u, '').trim();
+    if (!headingText) {
+      return;
+    }
+
 
     if (headingText.trim().startsWith('[') || headingText.trim().startsWith('`')) {
       return;

--- a/tests/emoji-heading.fixture.md
+++ b/tests/emoji-heading.fixture.md
@@ -1,0 +1,5 @@
+<!-- markdownlint-disable MD041 MD007 MD032 -->
+# 🚀 Quick start <!-- ✅ -->
+# 🚀 quick start <!-- ❌ -->
+# 🚀 Quick Start <!-- ❌ -->
+# 😀 <!-- ✅ -->

--- a/tests/emoji-heading.test.js
+++ b/tests/emoji-heading.test.js
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, test, expect } from '@jest/globals';
+import { lint } from 'markdownlint/promise';
+import sentenceCaseHeadingRule from '../.vscode/custom-rules/sentence-case-heading.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fixturePath = path.join(__dirname, 'emoji-heading.fixture.md');
+
+function parseFixture(filePath) {
+  return fs
+    .readFileSync(filePath, 'utf8')
+    .split('\n')
+    .reduce(
+      (acc, line, index) => {
+        if (line.includes('<!-- ✅ -->')) {
+          acc.passingLines.push(index + 1);
+        } else if (line.includes('<!-- ❌ -->')) {
+          acc.failingLines.push(index + 1);
+        }
+        return acc;
+      },
+      { passingLines: [], failingLines: [] }
+    );
+}
+
+describe('emoji sentence-case-heading rule', () => {
+  const { passingLines, failingLines } = parseFixture(fixturePath);
+
+  test('handles emoji-prefixed headings correctly', async () => {
+    const options = {
+      customRules: [sentenceCaseHeadingRule],
+      files: [fixturePath],
+      resultVersion: 3
+    };
+
+    const results = await lint(options);
+    const violations = results[fixturePath] || [];
+    const ruleViolations = violations.filter(v =>
+      v.ruleNames.includes('sentence-case-heading') || v.ruleNames.includes('SC001')
+    );
+
+    const failingNumbers = ruleViolations.map(v => v.lineNumber);
+    failingLines.forEach(line => {
+      expect(failingNumbers).toContain(line);
+    });
+    passingLines.forEach(line => {
+      expect(failingNumbers).not.toContain(line);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- handle emoji prefixes before running sentence-case logic
- add fixture with emoji headings
- test emoji support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684128cd07bc83339b3e6cb201a080c0