### PR TITLE
Extract fixture parser helper

### DIFF
--- a/tests/backtick-code-elements.test.js
+++ b/tests/backtick-code-elements.test.js
@@ -4,27 +4,12 @@ import { fileURLToPath } from 'url';
 import { describe, test, expect } from '@jest/globals';
 import { lint } from 'markdownlint/promise';
 import backtickRule from '../.vscode/custom-rules/backtick-code-elements.js';
+import { parseFixture } from './utils/fixture.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const fixturePath = path.join(__dirname, 'backtick-code-elements.fixture.md');
 
-function parseFixture(filePath) {
-  return fs
-    .readFileSync(filePath, 'utf8')
-    .split('\n')
-    .reduce(
-      (acc, line, index) => {
-        if (line.includes('<!-- ✅ -->')) {
-          acc.passingLines.push(index + 1);
-        } else if (line.includes('<!-- ❌ -->')) {
-          acc.failingLines.push(index + 1);
-        }
-        return acc;
-      },
-      { passingLines: [], failingLines: [] }
-    );
-}
 
 describe('backtick-code-elements rule', () => {
   const { passingLines, failingLines } = parseFixture(fixturePath);

--- a/tests/emoji-heading.test.js
+++ b/tests/emoji-heading.test.js
@@ -4,27 +4,12 @@ import { fileURLToPath } from 'url';
 import { describe, test, expect } from '@jest/globals';
 import { lint } from 'markdownlint/promise';
 import sentenceCaseHeadingRule from '../.vscode/custom-rules/sentence-case-heading.js';
+import { parseFixture } from './utils/fixture.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const fixturePath = path.join(__dirname, 'emoji-heading.fixture.md');
 
-function parseFixture(filePath) {
-  return fs
-    .readFileSync(filePath, 'utf8')
-    .split('\n')
-    .reduce(
-      (acc, line, index) => {
-        if (line.includes('<!-- ✅ -->')) {
-          acc.passingLines.push(index + 1);
-        } else if (line.includes('<!-- ❌ -->')) {
-          acc.failingLines.push(index + 1);
-        }
-        return acc;
-      },
-      { passingLines: [], failingLines: [] }
-    );
-}
 
 describe('emoji sentence-case-heading rule', () => {
   const { passingLines, failingLines } = parseFixture(fixturePath);

--- a/tests/utils/fixture.js
+++ b/tests/utils/fixture.js
@@ -1,0 +1,18 @@
+import fs from 'fs';
+
+export function parseFixture(filePath) {
+  return fs
+    .readFileSync(filePath, 'utf8')
+    .split('\n')
+    .reduce(
+      (acc, line, index) => {
+        if (line.includes('<!-- ✅ -->')) {
+          acc.passingLines.push(index + 1);
+        } else if (line.includes('<!-- ❌ -->')) {
+          acc.failingLines.push(index + 1);
+        }
+        return acc;
+      },
+      { passingLines: [], failingLines: [] }
+    );
+}


### PR DESCRIPTION
## Summary
- add a `parseFixture` helper in `tests/utils`
- remove duplicate helper code from short rule tests
- update the tests to import `parseFixture`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68412debe6008333b4ade3b9e22fc2eb