### PR TITLE
Improve documentation comments

### DIFF
--- a/.vscode/custom-rules/backtick-code-elements.js
+++ b/.vscode/custom-rules/backtick-code-elements.js
@@ -16,6 +16,14 @@ const ignoredTerms = new Set([
   'pass/fail',
   'Describe/test'
 ]);
+
+/**
+ * markdownlint rule enforcing backticks around file paths and commands.
+ *
+ * @param {import('markdownlint').RuleParams} params - Parsed Markdown input.
+ * @param {import('markdownlint').RuleOnError} onError - Callback to report violations.
+ * @returns {void}
+ */
 function backtickCodeElements(params, onError) {
   if (!params || !params.lines || typeof onError !== 'function') {
     return;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,3 +5,4 @@
 - [ ] **Automated release process** – Set up CI scripts to publish to npm and generate changelogs.
 - [ ] **VS Code extension integration** – Provide steps and configuration for bundling these rules into a VS Code extension.
 - [x] **Simplify test structure** – Map each fixture to a dedicated test file.
+- [ ] **Enhanced documentation** – Add missing JSDoc comments for functions and utilities.

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,6 +1,9 @@
 import createDebug from 'debug';
 
-// Base debug instance for the project
+/**
+ * Base debug instance for the project.
+ * Enable by setting `DEBUG=markdownlint-trap*`.
+ */
 const debug = createDebug('markdownlint-trap');
 
 export default debug;

--- a/tests/utils/fixture.js
+++ b/tests/utils/fixture.js
@@ -1,5 +1,11 @@
 import fs from 'fs';
 
+/**
+ * Read a fixture file and gather expected passing and failing lines.
+ *
+ * @param {string} filePath - Absolute path to the fixture file.
+ * @returns {{passingLines: number[], failingLines: number[]}} Line numbers grouped by outcome.
+ */
 export function parseFixture(filePath) {
   return fs
     .readFileSync(filePath, 'utf8')


### PR DESCRIPTION
## Summary
- add JSDoc comments for utility functions
- document logger usage
- note new documentation work in the roadmap

## Testing
- `npm test`
- `npx markdownlint-cli2 "**/*.md"`

------
https://chatgpt.com/codex/tasks/task_e_6843c74366008333b688318cfc12eccd