### PR TITLE
Update AGENTS with markdown formatting conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,14 @@ markdownlint-trap provides custom markdownlint rules enforcing consistent Markdo
 - Name variables and files for clarity over brevity
 - Mark provisional logic with `// TODO:` or `// FIXME:`
 
+## Markdown formatting conventions
+
+- Use backticks to wrap all:
+  - Filenames (e.g., `main.py`)
+  - Directories (e.g., `src/`)
+  - Code snippets, flags, and inline commands (e.g., `--help`)
+- Prefer fenced code blocks (` ``` `) for multi-line commands or examples
+
 ## Code clarity and documentation standards
 
 ### Naming and file metadata


### PR DESCRIPTION
## Summary
- document backtick convention in **Markdown formatting conventions** section

## Testing
- `npm test`
- `npx markdownlint-cli2 "**/*.md"`

------
https://chatgpt.com/codex/tasks/task_e_6844733012ec83338ee245041d48eee4