### PR TITLE
Fix custom markdownlint rules

### DIFF
--- a/tests/fixtures/backtick/failing.fixture.md
+++ b/tests/fixtures/backtick/failing.fixture.md
@@ -14,3 +14,4 @@ Open path/to/folder/ for logs <!-- ❌ -->
 Run mycmd(arg1, arg2) to start <!-- ❌ -->
 
 Look up the file "sample file.md" <!-- ❌ -->
+Check docs/api for more info <!-- ❌ -->

--- a/tests/fixtures/backtick/passing.fixture.md
+++ b/tests/fixtures/backtick/passing.fixture.md
@@ -221,3 +221,5 @@ Bones/Soft Tissues:   The bones and soft tissues are unremarkable for age. <!-- 
 Signed by: Monica Wood, M.D. <!-- ✅ -->
 **Exam:** Ultrasound, Abdominal, Limited, Single Organ/Quadrant <!-- ✅ -->
 - Father: High cholesterol, anxiety/depression <!-- ✅ -->
+Use the and/or operator in logic. <!-- ✅ -->
+A/B testing improves results. <!-- ✅ -->


### PR DESCRIPTION
## Summary
- refine backtick-code-elements rule: smarter path detection
- add tests for prose slashes

## Testing
- `npm test`
- `npx markdownlint-cli2 "**/*.md"`


------
https://chatgpt.com/codex/tasks/task_e_68461189774483338d161f32a0886719