### PR TITLE
Fix autofix fixture annotations

### DIFF
--- a/tests/fixtures/backtick/autofix-minimal.fixed.md
+++ b/tests/fixtures/backtick/autofix-minimal.fixed.md
@@ -1,7 +1,7 @@
 # Minimal auto-fix fixture
 
-Install `npm install` <!-- ❌ -->
+Install `npm install` <!-- ✅ -->
 
-Go to `src/utils` <!-- ❌ -->
+Go to `src/utils` <!-- ✅ -->
 
-Edit `config.yaml` <!-- ❌ -->
+Edit `config.yaml` <!-- ✅ -->

--- a/tests/fixtures/backtick/autofix.fixed.md
+++ b/tests/fixtures/backtick/autofix.fixed.md
@@ -2,24 +2,24 @@
 
 ## Multiple code elements on the same line
 
-Run `npm install` to set up your project and then install debug@latest. <!-- ❌ -->
+Run `npm install` to set up your project and then install debug@latest. <!-- ✅ -->
 
 ## File paths and commands
 
-Look in the `src/utils` directory and run `git clone` https://github.com/user/repo.git <!-- ❌ -->
+Look in the `src/utils` directory and run `git clone` https://github.com/user/repo.git <!-- ✅ -->
 
 ## Multiple elements spread across the document
 
-Edit `config.yaml` in the settings/ folder <!-- ❌ -->
+Edit `config.yaml` in the settings/ folder <!-- ✅ -->
 
-Run ./`build.sh` to compile the project <!-- ❌ -->
+Run ./`build.sh` to compile the project <!-- ✅ -->
 
-Add `import os` at the top of your script <!-- ❌ -->
+Add `import os` at the top of your script <!-- ✅ -->
 
 ## Nested code elements (should only fix outer ones)
 
-The command `echo PATH=/usr/bin` sets your path variable to /`usr/bin` <!-- ❌ -->
+The command `echo PATH=/usr/bin` sets your path variable to /`usr/bin` <!-- ✅ -->
 
 ## Elements after punctuation
 
-Open `readme.md`, `config.ini`, and `.env` for configuration. <!-- ❌ -->
+Open `readme.md`, `config.ini`, and `.env` for configuration. <!-- ✅ -->

--- a/tests/fixtures/sentence-case/autofix.fixed.md
+++ b/tests/fixtures/sentence-case/autofix.fixed.md
@@ -1,6 +1,6 @@
 # Auto-fix fixture for sentence-case-heading
 
-# This heading should be fixed <!-- ❌ -->
-# Another heading should also fail <!-- ❌ -->
-# Single word heading <!-- ❌ -->
-# Heading with `Code` example <!-- ❌ -->
+# This heading should be fixed <!-- ✅ -->
+# Another heading should also fail <!-- ✅ -->
+# Single word heading <!-- ✅ -->
+# Heading with `Code` example <!-- ✅ -->

--- a/tests/rules/backtick-autofix.test.js
+++ b/tests/rules/backtick-autofix.test.js
@@ -7,6 +7,16 @@ import { lint } from 'markdownlint/promise';
 import { applyFixes } from 'markdownlint';
 import backtickRule from '../../.vscode/custom-rules/backtick-code-elements.js';
 
+/**
+ * Normalize fixture markers for comparison.
+ *
+ * @param {string} content - Markdown text to normalize.
+ * @returns {string} Text with failing markers converted to passing markers.
+ */
+function normalizeMarkers(content) {
+  return content.replace(/<!--\s*❌\s*-->/g, '<!-- ✅ -->');
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const fixturePath = path.join(
@@ -55,9 +65,11 @@ describe('backtick-code-elements auto-fix functionality', () => {
     const fixed = applyFixes(fixtureContent, ruleFixes);
     fs.writeFileSync(tempFilePath, fixed, 'utf8');
     const fixedContent = fs.readFileSync(tempFilePath, 'utf8');
-    
-    // Compare with expected content
-    expect(fixedContent).toBe(expectedFixedContent);
+
+    // Compare with expected content using normalized markers
+    expect(normalizeMarkers(fixedContent)).toBe(
+      normalizeMarkers(expectedFixedContent)
+    );
   });
 
   test('correctly identifies violations', async () => {
@@ -109,7 +121,9 @@ describe('backtick-code-elements auto-fix functionality', () => {
     const fixed = applyFixes(minimalFixtureContent, minimalFixes);
     fs.writeFileSync(minimalTempFilePath, fixed, 'utf8');
     const fixedContent = fs.readFileSync(minimalTempFilePath, 'utf8');
-    expect(fixedContent).toBe(minimalExpectedContent);
+    expect(normalizeMarkers(fixedContent)).toBe(
+      normalizeMarkers(minimalExpectedContent)
+    );
 
     // Clean up
     if (fs.existsSync(minimalTempFilePath)) {

--- a/tests/rules/sentence-case-autofix.test.js
+++ b/tests/rules/sentence-case-autofix.test.js
@@ -7,6 +7,16 @@ import { lint } from 'markdownlint/promise';
 import { applyFixes } from 'markdownlint';
 import sentenceRule from '../../.vscode/custom-rules/sentence-case-heading.js';
 
+/**
+ * Convert failure markers to passing markers for comparison.
+ *
+ * @param {string} content - Markdown text to normalize.
+ * @returns {string} Text with failure markers replaced.
+ */
+function normalizeMarkers(content) {
+  return content.replace(/<!--\s*❌\s*-->/g, '<!-- ✅ -->');
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const fixturePath = path.join(
@@ -52,7 +62,9 @@ describe('sentence-case-heading auto-fix functionality', () => {
     const fixed = applyFixes(fixtureContent, fixes);
     fs.writeFileSync(tempFilePath, fixed, 'utf8');
     const fixedContent = fs.readFileSync(tempFilePath, 'utf8');
-    expect(fixedContent).toBe(expectedFixedContent);
+    expect(normalizeMarkers(fixedContent)).toBe(
+      normalizeMarkers(expectedFixedContent)
+    );
   });
 
   test('identifies violations in fixture', async () => {


### PR DESCRIPTION
## Summary
- update fixed fixtures to mark passing lines with ✅
- normalize markers in autofix tests so comments don't break comparisons

## Testing
- `npm test`
- `npx markdownlint-cli2 "**/*.md"`

------
https://chatgpt.com/codex/tasks/task_e_685e00a80d108333a5b8e6ac39c50943