### PR TITLE
Fix heading in wt-no-bare-urls fixture

### DIFF
--- a/tests/fixtures/wt-no-bare-urls.fixture.md
+++ b/tests/fixtures/wt-no-bare-urls.fixture.md
@@ -48,8 +48,6 @@ Reference style link: [Reference][1]. <!-- ✅ -->
 
 Autolink: <http://autolink.net>. <!-- ✅ -->
 
-### URLs with
-
 A URL used as link text is also fine: http://api.example.com. <!-- ❌ -->
 
 ### Non-URLs


### PR DESCRIPTION
## Summary
- remove stray partial heading in `wt-no-bare-urls.fixture.md`

## Testing
- `npm test`
- `npx markdownlint-cli2 "**/*.md"`


------
https://chatgpt.com/codex/tasks/task_e_685e00d123a883338244e20e540739f8