### PR TITLE
feat: add no-empty-list-items rule

### DIFF
--- a/recommended-config.jsonc
+++ b/recommended-config.jsonc
@@ -42,6 +42,7 @@
     "backtick-code-elements": true,
     "no-bare-url": true,
     "no-dead-internal-links": true,
-    "no-literal-ampersand": true
+    "no-literal-ampersand": true,
+    "no-empty-list-items": true
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import sentenceCaseHeading from './rules/sentence-case-heading.js';
 import noBareUrls from './rules/no-bare-urls.js';
 import noDeadInternalLinks from './rules/no-dead-internal-links.js';
 import noLiteralAmpersand from './rules/no-literal-ampersand.js';
+import noEmptyListItems from './rules/no-empty-list-items.js';
 
 // Export three-tier autofix system components
 export { THREE_TIER_THRESHOLDS, shouldApplyAutofix } from './rules/autofix-safety.js';
@@ -19,4 +20,4 @@ export {
  * Export all custom rules as a single array for markdownlint.
  * @type {import('markdownlint').Rule[]}
  */
-export default [backtickCodeElements, sentenceCaseHeading, noBareUrls, noDeadInternalLinks, noLiteralAmpersand];
+export default [backtickCodeElements, sentenceCaseHeading, noBareUrls, noDeadInternalLinks, noLiteralAmpersand, noEmptyListItems];

--- a/src/rules/no-empty-list-items.js
+++ b/src/rules/no-empty-list-items.js
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Rule to detect empty list items (common Word-to-Markdown conversion artifacts).
+ */
+
+/**
+ * @typedef {import("markdownlint").Rule} Rule
+ * @typedef {import("markdownlint").RuleParams} RuleParams
+ * @typedef {import("markdownlint").RuleOnError} RuleOnError
+ */
+
+/**
+ * Main rule implementation using micromark tokens.
+ * Detects list items that have no content (only whitespace after the marker).
+ * @param {RuleParams} params - Parsed Markdown input
+ * @param {RuleOnError} onError - Callback to report violations
+ */
+function noEmptyListItems(params, onError) {
+  const tokens = params.parsers?.micromark?.tokens || [];
+
+  for (const token of tokens) {
+    if (token.type !== "listUnordered" && token.type !== "listOrdered") {
+      continue;
+    }
+
+    const children = token.children || [];
+    for (let i = 0; i < children.length; i++) {
+      if (children[i].type !== "listItemPrefix") {
+        continue;
+      }
+
+      // Check if the next meaningful sibling is content
+      const next = children[i + 1];
+      const hasContent = next && next.type === "content";
+
+      if (!hasContent) {
+        onError({
+          lineNumber: children[i].startLine,
+          detail: "Empty list item found",
+          context: params.lines[children[i].startLine - 1].trim(),
+          fixInfo: {
+            deleteCount: -1,
+          },
+        });
+      }
+    }
+  }
+}
+
+/** @type {Rule} */
+export default {
+  names: ["no-empty-list-items", "ELI001"],
+  description: "Empty list items are not allowed",
+  tags: ["lists", "blank_lines"],
+  parser: "micromark",
+  function: noEmptyListItems,
+};

--- a/strict-config.jsonc
+++ b/strict-config.jsonc
@@ -16,7 +16,8 @@
     "backtick-code-elements": true,
     "no-bare-url": true,
     "no-dead-internal-links": true,
-    "no-literal-ampersand": true
+    "no-literal-ampersand": true,
+    "no-empty-list-items": true
   }
 }
 

--- a/tests/features/no-empty-list-items.test.js
+++ b/tests/features/no-empty-list-items.test.js
@@ -1,0 +1,88 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import { describe, test, expect, beforeAll } from "@jest/globals";
+import { lint } from "markdownlint/promise";
+import noEmptyListItems from "../../src/rules/no-empty-list-items.js";
+import { parseFixture } from "../utils/fixture.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fixturePath = path.join(
+  __dirname,
+  "../fixtures/no-empty-list-items.fixture.md",
+);
+
+/**
+ * @integration
+ * Test suite for no-empty-list-items custom rule.
+ * Ensures that empty list items are detected and reported on the correct lines.
+ */
+describe("no-empty-list-items rule", () => {
+  const { failingLines } = parseFixture(fixturePath);
+  let violations = [];
+
+  beforeAll(async () => {
+    const options = {
+      files: [fixturePath],
+      customRules: [noEmptyListItems],
+      config: {
+        default: false,
+        "no-empty-list-items": true,
+      },
+    };
+    violations = await lint(options);
+  });
+
+  test("detects and reports all empty list items on correct lines", () => {
+    const errorLines = [
+      ...new Set(violations[fixturePath].map((v) => v.lineNumber)),
+    ];
+    expect(errorLines.sort((a, b) => a - b)).toEqual(failingLines.sort((a, b) => a - b));
+  });
+
+  test("does not flag non-empty list items", () => {
+    const { passingLines } = parseFixture(fixturePath);
+    const errorLines = violations[fixturePath].map((v) => v.lineNumber);
+    for (const line of passingLines) {
+      expect(errorLines).not.toContain(line);
+    }
+  });
+
+  test("provides fixInfo to delete the empty list item line", () => {
+    for (const violation of violations[fixturePath]) {
+      expect(violation.fixInfo).toBeDefined();
+      expect(violation.fixInfo.deleteCount).toBe(-1);
+    }
+  });
+});
+
+describe("no-empty-list-items rule with inline content", () => {
+  test("flags empty unordered items in string input", async () => {
+    const results = await lint({
+      strings: { test: "- First\n- \n- Third\n" },
+      customRules: [noEmptyListItems],
+      config: { default: false, "no-empty-list-items": true },
+    });
+    expect(results.test.length).toBe(1);
+    expect(results.test[0].lineNumber).toBe(2);
+  });
+
+  test("flags empty ordered items in string input", async () => {
+    const results = await lint({
+      strings: { test: "1. First\n2. \n3. Third\n" },
+      customRules: [noEmptyListItems],
+      config: { default: false, "no-empty-list-items": true },
+    });
+    expect(results.test.length).toBe(1);
+    expect(results.test[0].lineNumber).toBe(2);
+  });
+
+  test("does not flag items with content", async () => {
+    const results = await lint({
+      strings: { test: "- Has content\n- Also content\n" },
+      customRules: [noEmptyListItems],
+      config: { default: false, "no-empty-list-items": true },
+    });
+    expect(results.test.length).toBe(0);
+  });
+});

--- a/tests/fixtures/no-empty-list-items.fixture.md
+++ b/tests/fixtures/no-empty-list-items.fixture.md
@@ -1,0 +1,47 @@
+# Fixture for no-empty-list-items rule
+
+## Valid cases (should not trigger the rule)
+
+- First item <!-- ✅ -->
+- Second item <!-- ✅ -->
+- Third item <!-- ✅ -->
+
+* Star item <!-- ✅ -->
+* Another star <!-- ✅ -->
+
++ Plus item <!-- ✅ -->
++ Another plus <!-- ✅ -->
+
+1. Ordered first <!-- ✅ -->
+2. Ordered second <!-- ✅ -->
+
+- Item with nested list <!-- ✅ -->
+  - Nested item <!-- ✅ -->
+
+## Invalid cases (should trigger the rule)
+
+### Unordered empty items
+
+-  <!-- ❌ -->
+
+*  <!-- ❌ -->
+
++  <!-- ❌ -->
+
+### Ordered empty items
+
+1.  <!-- ❌ -->
+
+2.  <!-- ❌ -->
+
+### Mixed with valid items
+
+- Valid item <!-- ✅ -->
+-  <!-- ❌ -->
+- Another valid item <!-- ✅ -->
+
+### Whitespace-only content
+
+-   <!-- ❌ -->
+*    <!-- ❌ -->
+1.    <!-- ❌ -->

--- a/tests/integration/esm-compatibility.test.js
+++ b/tests/integration/esm-compatibility.test.js
@@ -33,7 +33,7 @@ describe('Native ESM compatibility', () => {
     
     expect(allRules.default).toBeDefined();
     expect(Array.isArray(allRules.default)).toBe(true);
-    expect(allRules.default.length).toBe(5);
+    expect(allRules.default.length).toBe(6);
     
     // Verify each rule has the expected structure
     allRules.default.forEach(rule => {
@@ -100,7 +100,7 @@ describe('Native ESM compatibility', () => {
     const rules = await import(mainPath);
     expect(rules.default).toBeDefined();
     expect(Array.isArray(rules.default)).toBe(true);
-    expect(rules.default.length).toBe(5);
+    expect(rules.default.length).toBe(6);
   });
 
   test('test_should_work_when_imported_by_rule_name', async () => {
@@ -168,7 +168,7 @@ describe('Backward compatibility', () => {
     // CJS consumers using dynamic import get the module with .default property
     expect(rules.default).toBeDefined();
     expect(Array.isArray(rules.default)).toBe(true);
-    expect(rules.default.length).toBe(5);
+    expect(rules.default.length).toBe(6);
 
     // Document the correct pattern for CJS consumers:
     // const rules = await import('markdownlint-trap');
@@ -189,7 +189,8 @@ describe('Backward compatibility', () => {
       'sentence-case-heading',
       'no-bare-url',
       'no-dead-internal-links',
-      'no-literal-ampersand'
+      'no-literal-ampersand',
+      'no-empty-list-items'
     ];
     
     const actualRuleNames = allRules.default.flatMap(rule => rule.names);


### PR DESCRIPTION
## Summary

Closes #132

- Add `no-empty-list-items` rule (ELI001) that detects empty list items, a common artifact from Word-to-Markdown conversion
- Uses micromark token API to detect unordered and ordered list items lacking content
- Provides `fixInfo` with `deleteCount: -1` to remove empty items via autofix
- Registered in `src/index.js` and enabled in `recommended` and `strict` config presets
- Includes fixture-based and inline string tests (6 tests, all passing)
- Updated ESM compatibility tests to account for the new 6th rule

## Test plan

- [x] Feature tests pass: `npm test -- tests/features/no-empty-list-items.test.js`
- [x] ESM compatibility tests updated and pass
- [x] Full test suite passes (71/71 suites, 1336 tests)
- [x] ESLint clean on all changed files
- [x] Pre-push hooks pass on all three remotes