### PR TITLE
Precompile autofix safety patterns at module load time

### DIFF
--- a/src/rules/autofix-safety.js
+++ b/src/rules/autofix-safety.js
@@ -170,6 +170,57 @@ const TECHNICAL_INDICATORS = [
 ];
 
 /**
+ * Precompiled regex for technical term detection in sentence case confidence.
+ * Hoisted to module scope to avoid recompilation on every call.
+ * @type {RegExp}
+ */
+const TECHNICAL_TERM_PATTERN = /\b(API|URL|HTML|CSS|JSON|XML|HTTP|HTTPS|SDK|CLI|GUI|UI|UX|SQL|NoSQL|REST|GraphQL|JWT|OAuth|CSRF|XSS|CORS|DNS|CDN|VPN|SSL|TLS|SSH|FTP|SMTP|POP|IMAP|TCP|UDP|IP|IPv4|IPv6|MAC|VLAN|LAN|WAN|WiFi|Bluetooth|USB|HDMI|GPU|CPU|RAM|SSD|HDD|OS|iOS|Android|Windows|Linux|macOS|Unix|AWS|Azure|GCP|Docker|Kubernetes|Git|GitHub|GitLab|npm|yarn|pip|conda|Maven|Gradle|Webpack|Rollup|Vite|React|Vue|Angular|Next|Nuxt|Express|Django|Flask|Rails|Laravel|Spring|Hibernate|MongoDB|PostgreSQL|MySQL|Redis|Elasticsearch|Kafka|RabbitMQ|Jenkins|CircleCI|GitHub Actions|Travis|Azure DevOps|Terraform|Ansible|Puppet|Chef|Vagrant|VMware|VirtualBox|Hyper-V|KVM|Xen|Node\.js|Python|Java|JavaScript|TypeScript|C\+\+|C#|Go|Rust|Swift|Kotlin|Scala|Ruby|PHP|Perl|R|MATLAB|Stata|SAS|SPSS|Tableau|PowerBI|Excel|Word|PowerPoint|Outlook|Teams|Slack|Discord|Zoom|WebEx|Skype|WhatsApp|Telegram|Signal|Firefox|Chrome|Safari|Edge|Opera|Brave|Tor|VPN|Proxy|Firewall|Antivirus|Malware|Ransomware|Phishing|Spear-phishing|Social engineering|Two-factor authentication|Multi-factor authentication|Single sign-on|Identity and access management|Role-based access control|Attribute-based access control|Discretionary access control|Mandatory access control|Bell-LaPadula|Biba|Clark-Wilson|Chinese Wall|Take-Grant|HRU|RBAC|ABAC|DAC|MAC|BLP|Biba|CW|TG|HRU)\b/gi;
+
+/**
+ * Precompiled patterns for definite natural language detection.
+ * Used in analyzeCodeVsNaturalLanguage to immediately disqualify common English words.
+ * @type {RegExp[]}
+ */
+const DEFINITELY_NOT_CODE = [
+  /^(a|an|the|and|or|but|if|then|else|when|where|why|how|who|what|which|that|this|these|those|here|there|now|today|yesterday|tomorrow)$/i,
+  /^(i|you|he|she|it|we|they|me|him|her|us|them|my|your|his|her|its|our|their)$/i,
+  /^(is|are|was|were|be|been|being|have|has|had|do|does|did|will|would|could|should|may|might|can|must|shall)$/i,
+  /^(good|bad|big|small|new|old|first|last|next|previous|best|worst|better|worse|more|less|most|least)$/i,
+  /^(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|twenty|thirty|hundred|thousand)$/i
+];
+
+/**
+ * Precompiled strong code indicator patterns.
+ * Built from FILE_EXTENSION_KEYWORDS and COMMAND_KEYWORDS sets at module load time.
+ * @type {RegExp[]}
+ */
+const STRONG_CODE_INDICATORS = [
+  new RegExp(`\\.(${Array.from(FILE_EXTENSION_KEYWORDS).join('|')})$`, 'i'),
+  /^[A-Z_][A-Z0-9_]*$/, // ENVIRONMENT_VARIABLES
+  new RegExp(`^(${Array.from(COMMAND_KEYWORDS).join('|')})\\s`),
+  /\(.*\)$/, // Function calls
+  /^import\s+/,
+  /^from\s+.*import/,
+  /^\$[A-Z_]+$/, // Shell variables
+  /^--[a-z-]+$/, // Command flags
+  /\/.*\//, // Paths with slashes
+  /^\.[a-zA-Z]/ // Dotfiles
+];
+
+/**
+ * Precompiled moderate code indicator patterns.
+ * @type {RegExp[]}
+ */
+const MODERATE_CODE_INDICATORS = [
+  /[A-Z]{2,}/, // Contains acronyms
+  /_/, // Contains underscores
+  /\d/, // Contains numbers
+  /^[a-z]+[A-Z]/, // camelCase
+  /^[A-Z][a-z]+[A-Z]/, // PascalCase
+  /^[a-z-]{4,}$/ // kebab-case (only if longer than 3 chars)
+];
+
+/**
  * Extract file extension from a filename or path
  * @param {string} filename - The filename or path
  * @returns {string} The file extension (without the dot)
@@ -277,9 +328,9 @@ export function calculateSentenceCaseConfidence(original, fixed, context = {}) {
 
   // +0.1 per technical term (max +0.3): Slight confidence boost for technical content
   // Technical content often has specific capitalization rules that should be preserved
-  const technicalTermPattern = /\b(API|URL|HTML|CSS|JSON|XML|HTTP|HTTPS|SDK|CLI|GUI|UI|UX|SQL|NoSQL|REST|GraphQL|JWT|OAuth|CSRF|XSS|CORS|DNS|CDN|VPN|SSL|TLS|SSH|FTP|SMTP|POP|IMAP|TCP|UDP|IP|IPv4|IPv6|MAC|VLAN|LAN|WAN|WiFi|Bluetooth|USB|HDMI|GPU|CPU|RAM|SSD|HDD|OS|iOS|Android|Windows|Linux|macOS|Unix|AWS|Azure|GCP|Docker|Kubernetes|Git|GitHub|GitLab|npm|yarn|pip|conda|Maven|Gradle|Webpack|Rollup|Vite|React|Vue|Angular|Next|Nuxt|Express|Django|Flask|Rails|Laravel|Spring|Hibernate|MongoDB|PostgreSQL|MySQL|Redis|Elasticsearch|Kafka|RabbitMQ|Jenkins|CircleCI|GitHub Actions|Travis|Azure DevOps|Terraform|Ansible|Puppet|Chef|Vagrant|VMware|VirtualBox|Hyper-V|KVM|Xen|Node\.js|Python|Java|JavaScript|TypeScript|C\+\+|C#|Go|Rust|Swift|Kotlin|Scala|Ruby|PHP|Perl|R|MATLAB|Stata|SAS|SPSS|Tableau|PowerBI|Excel|Word|PowerPoint|Outlook|Teams|Slack|Discord|Zoom|WebEx|Skype|WhatsApp|Telegram|Signal|Firefox|Chrome|Safari|Edge|Opera|Brave|Tor|VPN|Proxy|Firewall|Antivirus|Malware|Ransomware|Phishing|Spear-phishing|Social engineering|Two-factor authentication|Multi-factor authentication|Single sign-on|Identity and access management|Role-based access control|Attribute-based access control|Discretionary access control|Mandatory access control|Bell-LaPadula|Biba|Clark-Wilson|Chinese Wall|Take-Grant|HRU|RBAC|ABAC|DAC|MAC|BLP|Biba|CW|TG|HRU)\b/gi;
-
-  const technicalMatches = (original.match(technicalTermPattern) || []).length;
+  // Reset lastIndex since TECHNICAL_TERM_PATTERN is a global regex reused across calls
+  TECHNICAL_TERM_PATTERN.lastIndex = 0;
+  const technicalMatches = (original.match(TECHNICAL_TERM_PATTERN) || []).length;
   if (technicalMatches > 0) {
     const boost = 0.1 * Math.min(technicalMatches, 3);
     heuristics.technicalTerms = boost;
@@ -510,52 +561,22 @@ export function analyzeCodeVsNaturalLanguage(text, context = {}) {
     shouldAutofix: false
   };
 
-  // Immediate disqualifiers for common natural language
-  const definitelyNotCode = [
-    /^(a|an|the|and|or|but|if|then|else|when|where|why|how|who|what|which|that|this|these|those|here|there|now|today|yesterday|tomorrow)$/i,
-    /^(i|you|he|she|it|we|they|me|him|her|us|them|my|your|his|her|its|our|their)$/i,
-    /^(is|are|was|were|be|been|being|have|has|had|do|does|did|will|would|could|should|may|might|can|must|shall)$/i,
-    /^(good|bad|big|small|new|old|first|last|next|previous|best|worst|better|worse|more|less|most|least)$/i,
-    /^(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|twenty|thirty|hundred|thousand)$/i
-  ];
-
-  if (definitelyNotCode.some(pattern => pattern.test(text))) {
+  // Immediate disqualifiers for common natural language (precompiled at module level)
+  if (DEFINITELY_NOT_CODE.some(pattern => pattern.test(text))) {
     analysis.confidence = 0.1;
     analysis.reasons.push('Matches common English word pattern');
     return analysis;
   }
 
-  // Strong code indicators
-  const strongCodeIndicators = [
-    new RegExp(`\\.(${Array.from(FILE_EXTENSION_KEYWORDS).join('|')})$`, 'i'),
-    /^[A-Z_][A-Z0-9_]*$/, // ENVIRONMENT_VARIABLES
-    new RegExp(`^(${Array.from(COMMAND_KEYWORDS).join('|')})\\s`),
-    /\(.*\)$/, // Function calls
-    /^import\s+/,
-    /^from\s+.*import/,
-    /^\$[A-Z_]+$/, // Shell variables
-    /^--[a-z-]+$/, // Command flags
-    /\/.*\//, // Paths with slashes
-    /^\.[a-zA-Z]/ // Dotfiles
-  ];
-
-  const strongMatches = strongCodeIndicators.filter(pattern => pattern.test(text));
+  // Strong code indicators (precompiled at module level)
+  const strongMatches = STRONG_CODE_INDICATORS.filter(pattern => pattern.test(text));
   if (strongMatches.length > 0) {
     analysis.confidence += 0.4;
     analysis.reasons.push(`Strong code pattern: ${strongMatches.length} matches`);
   }
 
-  // Moderate code indicators
-  const moderateCodeIndicators = [
-    /[A-Z]{2,}/, // Contains acronyms
-    /_/, // Contains underscores
-    /\d/, // Contains numbers
-    /^[a-z]+[A-Z]/, // camelCase
-    /^[A-Z][a-z]+[A-Z]/, // PascalCase
-    /^[a-z-]{4,}$/ // kebab-case (only if longer than 3 chars)
-  ];
-
-  const moderateMatches = moderateCodeIndicators.filter(pattern => pattern.test(text));
+  // Moderate code indicators (precompiled at module level)
+  const moderateMatches = MODERATE_CODE_INDICATORS.filter(pattern => pattern.test(text));
   if (moderateMatches.length > 0) {
     analysis.confidence += 0.1 * moderateMatches.length;
     analysis.reasons.push(`Moderate code patterns: ${moderateMatches.length} matches`);

--- a/tests/unit/autofix-pattern-precompile.test.js
+++ b/tests/unit/autofix-pattern-precompile.test.js
@@ -1,0 +1,159 @@
+/**
+ * Tests that precompiled patterns in autofix-safety.js produce identical
+ * results to the original per-call compilation approach.
+ *
+ * These tests pin the exact behavior of analyzeCodeVsNaturalLanguage,
+ * calculateSentenceCaseConfidence, and calculateBacktickConfidence to
+ * ensure the precompile refactor is a pure no-op on outputs.
+ */
+import { describe, test, expect } from '@jest/globals';
+import {
+  analyzeCodeVsNaturalLanguage,
+  calculateSentenceCaseConfidence,
+  calculateBacktickConfidence,
+  shouldApplyAutofix
+} from '../../src/rules/autofix-safety.js';
+
+describe('Precompiled pattern equivalence', () => {
+  describe('analyzeCodeVsNaturalLanguage pinned outputs', () => {
+    const cases = [
+      // Definite natural language words
+      { text: 'the', expectLikelyCode: false, expectLowConfidence: true },
+      { text: 'is', expectLikelyCode: false, expectLowConfidence: true },
+      { text: 'you', expectLikelyCode: false, expectLowConfidence: true },
+      { text: 'three', expectLikelyCode: false, expectLowConfidence: true },
+      { text: 'red', expectLikelyCode: false, expectLowConfidence: false },
+      // Strong code indicators
+      { text: 'package.json', expectLikelyCode: true, expectLowConfidence: false },
+      { text: 'npm install express', expectLikelyCode: true, expectLowConfidence: false },
+      { text: 'ENVIRONMENT_VAR', expectLikelyCode: true, expectLowConfidence: false },
+      { text: '--verbose', expectLikelyCode: true, expectLowConfidence: false },
+      { text: 'src/index.js', expectLikelyCode: true, expectLowConfidence: false },
+      { text: '.gitignore', expectLikelyCode: true, expectLowConfidence: false },
+      { text: 'import React', expectLikelyCode: true, expectLowConfidence: false },
+      { text: '$HOME', expectLikelyCode: true, expectLowConfidence: false },
+      // Moderate code indicators
+      { text: 'fetchData', expectLikelyCode: true, expectLowConfidence: false },
+      { text: 'my_variable', expectLikelyCode: true, expectLowConfidence: false },
+      { text: 'MyComponent', expectLikelyCode: true, expectLowConfidence: false },
+    ];
+
+    for (const { text, expectLikelyCode, expectLowConfidence } of cases) {
+      test(`should classify "${text}" correctly`, () => {
+        const result = analyzeCodeVsNaturalLanguage(text, {});
+        expect(result.isLikelyCode).toBe(expectLikelyCode);
+        if (expectLowConfidence) {
+          expect(result.confidence).toBeLessThanOrEqual(0.2);
+        }
+      });
+    }
+
+    test('should apply context-based adjustments', () => {
+      const techResult = analyzeCodeVsNaturalLanguage('webpack', {
+        line: 'Run the command to install webpack'
+      });
+      const proseResult = analyzeCodeVsNaturalLanguage('webpack', {
+        line: 'For example, webpack is like a bundler'
+      });
+      // Technical context should boost, example context should penalize
+      expect(techResult.confidence).toBeGreaterThan(proseResult.confidence);
+    });
+  });
+
+  describe('calculateSentenceCaseConfidence pinned outputs', () => {
+    test('should return 0 confidence for empty or identical inputs', () => {
+      expect(calculateSentenceCaseConfidence('', '', {}).confidence).toBe(0);
+      expect(calculateSentenceCaseConfidence('Hello', 'Hello', {}).confidence).toBe(0);
+      expect(calculateSentenceCaseConfidence(null, null, {}).confidence).toBe(0);
+    });
+
+    test('should boost for first-word capitalization fix', () => {
+      const result = calculateSentenceCaseConfidence('HELLO WORLD', 'Hello world', {});
+      expect(result.confidence).toBeGreaterThanOrEqual(0.7);
+      expect(result.heuristics.firstWordCapitalization).toBe(0.3);
+    });
+
+    test('should boost for case-only changes', () => {
+      const result = calculateSentenceCaseConfidence('Hello World', 'hello world', {});
+      expect(result.heuristics.caseChangesOnly).toBe(0.2);
+    });
+
+    test('should detect technical terms in text', () => {
+      const withTech = calculateSentenceCaseConfidence(
+        'Configure API and REST endpoints',
+        'configure API and REST endpoints',
+        {}
+      );
+      const withoutTech = calculateSentenceCaseConfidence(
+        'Configure the things',
+        'configure the things',
+        {}
+      );
+      expect(withTech.heuristics.technicalTerms).toBeGreaterThan(0);
+      expect(withoutTech.heuristics.technicalTerms).toBe(0);
+    });
+  });
+
+  describe('Deterministic outputs across multiple calls', () => {
+    test('analyzeCodeVsNaturalLanguage returns same result on repeated calls', () => {
+      const inputs = ['npm', 'package.json', 'hello', 'the', '--flag', 'fetchData'];
+      for (const text of inputs) {
+        const r1 = analyzeCodeVsNaturalLanguage(text, {});
+        const r2 = analyzeCodeVsNaturalLanguage(text, {});
+        expect(r1.confidence).toBe(r2.confidence);
+        expect(r1.isLikelyCode).toBe(r2.isLikelyCode);
+        expect(r1.shouldAutofix).toBe(r2.shouldAutofix);
+        expect(r1.reasons).toEqual(r2.reasons);
+      }
+    });
+
+    test('calculateSentenceCaseConfidence returns same result on repeated calls', () => {
+      const pairs = [
+        ['API Gateway Setup', 'API gateway setup'],
+        ['HELLO WORLD', 'Hello world'],
+        ['Configure REST API', 'configure REST API'],
+      ];
+      for (const [orig, fixed] of pairs) {
+        const r1 = calculateSentenceCaseConfidence(orig, fixed, {});
+        const r2 = calculateSentenceCaseConfidence(orig, fixed, {});
+        expect(r1.confidence).toBe(r2.confidence);
+        expect(r1.heuristics).toEqual(r2.heuristics);
+      }
+    });
+
+    test('calculateBacktickConfidence returns same result on repeated calls', () => {
+      const inputs = ['npm', 'package.json', 'hello', 'src/index.js'];
+      for (const text of inputs) {
+        const r1 = calculateBacktickConfidence(text, {});
+        const r2 = calculateBacktickConfidence(text, {});
+        expect(r1.confidence).toBe(r2.confidence);
+        expect(r1.heuristics).toEqual(r2.heuristics);
+      }
+    });
+  });
+
+  describe('shouldApplyAutofix integration with precompiled patterns', () => {
+    const config = {
+      enabled: true,
+      confidenceThreshold: 0.7,
+      reviewThreshold: 0.3
+    };
+
+    test('should produce identical tier results across calls', () => {
+      const cases = [
+        ['sentence-case', 'HELLO WORLD', 'Hello world'],
+        ['backtick', 'package.json', '`package.json`'],
+        ['backtick', 'the', '`the`'],
+        ['no-bare-url', 'https://example.com', '<https://example.com>'],
+      ];
+
+      for (const [rule, orig, fixed] of cases) {
+        const r1 = shouldApplyAutofix(rule, orig, fixed, {}, config);
+        const r2 = shouldApplyAutofix(rule, orig, fixed, {}, config);
+        expect(r1.tier).toBe(r2.tier);
+        expect(r1.confidence).toBe(r2.confidence);
+        expect(r1.safe).toBe(r2.safe);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Hoists regex patterns that were rebuilt on every function call in `autofix-safety.js` to module-level constants compiled once at load time:

- **TECHNICAL_TERM_PATTERN**: ~200-term regex used by `calculateSentenceCaseConfidence` (moved from inline to module scope with `lastIndex` reset for global regex reuse)
- **DEFINITELY_NOT_CODE**: 5 regex patterns used by `analyzeCodeVsNaturalLanguage` for natural language disqualification
- **STRONG_CODE_INDICATORS**: 10 regex patterns including 2 dynamically built from `FILE_EXTENSION_KEYWORDS` and `COMMAND_KEYWORDS` Sets
- **MODERATE_CODE_INDICATORS**: 6 regex patterns for secondary code detection

This eliminates redundant pattern compilation on every violation, improving performance on large documents with many violations. Pure refactor -- behavior is unchanged.

Closes #69

## Test plan

### Automated testing
- [x] Unit tests pass (25 new tests in `autofix-pattern-precompile.test.js`)
- [x] All existing tests pass (71 suites, 1355 tests)
- [x] Performance benchmarks pass
- [x] Full test suite passes
- [x] ESLint passes

### Test coverage
- [x] Pinned outputs for `analyzeCodeVsNaturalLanguage` (natural language and code inputs)
- [x] Context-based adjustment verification
- [x] `calculateSentenceCaseConfidence` pinned outputs
- [x] Deterministic output verification across repeated calls (all 3 functions)
- [x] `shouldApplyAutofix` integration with precompiled patterns

## Breaking changes

None -- backward compatible, pure internal refactor.