### PR TITLE
fix: add PDFs to ignored acronym plurals

### DIFF
--- a/src/rules/shared-constants.js
+++ b/src/rules/shared-constants.js
@@ -566,6 +566,7 @@ const additionalBacktickIgnoredTerms = [
   'GUIs',
   'CLIs',
   'APIs',
+  'PDFs',
   // Module system names (proper nouns)
   'CommonJS',
   'ESM',

--- a/tests/features/backtick-passing.test.js
+++ b/tests/features/backtick-passing.test.js
@@ -63,6 +63,24 @@ test("does not flag regular prose with slashes as file path", async () => {
 /**
  * Verifies that common non-code terms like "et al." are not flagged as missing backticks.
  */
+test('does not flag plural acronym "PDFs" as a code identifier (#161)', async () => {
+  const markdown = "Include trigger terms (e.g., when the user mentions PDFs, forms, or document extraction)";
+  const options = {
+    customRules: [backtickRule],
+    strings: { "test.md": markdown },
+    resultVersion: 3,
+    config: { "backtick-code-elements": { detectPascalCase: true } },
+  };
+  const results = await lint(options);
+  const violations = results["test.md"] || [];
+  const ruleViolations = violations.filter(
+    (v) =>
+      v.ruleNames.includes("backtick-code-elements") ||
+      v.ruleNames.includes("BCE001"),
+  );
+  expect(ruleViolations).toHaveLength(0);
+});
+
 test('does not flag "et al." as missing backticks', async () => {
   const markdown =
     "As described by Smith et al., the results were significant.";


### PR DESCRIPTION
Closes #161

## Summary

- Add "PDFs" to `additionalBacktickIgnoredTerms` in `shared-constants.js`
- "PDFs" is a standard plural acronym like "APIs", "URLs", "SDKs" already in the list
- Add test verifying "PDFs" is not flagged as a code identifier

## Test plan

- [x] Wrote failing test for "PDFs" false positive (red)
- [x] Added "PDFs" to ignored terms list (green)
- [x] `npm run validate` passes