### PR TITLE
fix: add word boundaries to import regex

### DIFF
--- a/src/rules/backtick-code-elements.js
+++ b/src/rules/backtick-code-elements.js
@@ -640,7 +640,8 @@ function backtickCodeElements(params, onError) {
       // import statements - exclude common English words after "import"
       // This catches "import pdfplumber" but not "import them", "import system", etc.
       // Exclusion list covers pronouns, articles, prepositions, and common nouns
-      /\bimport\s+(?!the|a|an|your|my|our|their|its|some|all|any|this|that|these|those|from|into|to|new|old|more|them|it|something|everything|anything|nothing|system|systems|updates|path|paths|is|are|was|were|will|be|data|files|modules|packages|settings|config|options|rules|code|process|other|changes|and|or|statements|functions|classes|types|errors|values|items|records|content|text|names|custom|external|internal|local|global|default|specific|relevant|existing|additional|required|necessary|important|direct|proper)\w+/g,
+      // Each alternative uses \b to prevent prefix-matching (e.g., "to" blocking "tokenizer")
+      /\bimport\s+(?!(?:the|a|an|your|my|our|their|its|some|all|any|this|that|these|those|from|into|to|new|old|more|them|it|something|everything|anything|nothing|system|systems|updates|path|paths|is|are|was|were|will|be|data|files|modules|packages|settings|config|options|rules|code|process|other|changes|and|or|statements|functions|classes|types|errors|values|items|records|content|text|names|custom|external|internal|local|global|default|specific|relevant|existing|additional|required|necessary|important|direct|proper|tool|tools)\b)\w+/g,
       // host:port patterns, avoids bible verses like "1:10" and WCAG ratios like "4.5:1"
       // Time ranges like "AM-12:30", "3-10:30" are filtered out separately
       // Negative lookbehind: not preceded by decimal number (WCAG ratios)

--- a/tests/features/backtick-passing.test.js
+++ b/tests/features/backtick-passing.test.js
@@ -121,6 +121,41 @@ test('flags multi-segment tilde path as complete unit (#162)', async () => {
   expect(ruleViolations[0].errorDetail).toMatch(/~\/Documents\/file\.txt/);
 });
 
+test('does not flag "import tool" or "import new" as code statements (#160)', async () => {
+  const markdown = "Use the import tool to bring in data. You can import new items from the list.";
+  const options = {
+    customRules: [backtickRule],
+    strings: { "test.md": markdown },
+    resultVersion: 3,
+  };
+  const results = await lint(options);
+  const violations = results["test.md"] || [];
+  const ruleViolations = violations.filter(
+    (v) =>
+      v.ruleNames.includes("backtick-code-elements") ||
+      v.ruleNames.includes("BCE001"),
+  );
+  expect(ruleViolations).toHaveLength(0);
+});
+
+test('flags actual code import like "import tokenizer" after word boundary fix (#160)', async () => {
+  const markdown = "You should use import tokenizer in your Python script.";
+  const options = {
+    customRules: [backtickRule],
+    strings: { "test.md": markdown },
+    resultVersion: 3,
+  };
+  const results = await lint(options);
+  const violations = results["test.md"] || [];
+  const ruleViolations = violations.filter(
+    (v) =>
+      v.ruleNames.includes("backtick-code-elements") ||
+      v.ruleNames.includes("BCE001"),
+  );
+  expect(ruleViolations.length).toBeGreaterThan(0);
+  expect(ruleViolations[0].errorDetail).toMatch(/import tokenizer/);
+});
+
 test('does not flag "et al." as missing backticks', async () => {
   const markdown =
     "As described by Smith et al., the results were significant.";


### PR DESCRIPTION
Closes #160

## Summary

- Add `\b` word boundary after each alternative in the import statement negative lookahead regex
- Without word boundaries, short words like "to" incorrectly blocked longer words like "tokenizer", "tomllib" from being flagged as code imports
- Add "tool" and "tools" to the exclusion list as common English prose words
- Now `import tokenizer`, `import newspaper` are correctly flagged while `import tool`, `import new` remain excluded

## Test plan

- [x] Test: "import tool" and "import new" are not flagged (prose exclusion)
- [x] Test: "import tokenizer" IS flagged (code import correctly detected after fix)
- [x] All feature tests pass (767/767)
- [x] `npm run validate` passes