### PR TITLE
fix(sc001): skip ALL-CAPS filenames in headings

### DIFF
--- a/src/rules/sentence-case/case-classifier.js
+++ b/src/rules/sentence-case/case-classifier.js
@@ -541,6 +541,15 @@ function validateSubsequentWords(words, startIndex, phraseIgnore, specialCasedTe
       }
     }
 
+    // Skip ALL-CAPS words that are part of a filename in the original text
+    // (e.g., "LICENSE" from "LICENSE.md" after dot removal in the clean step)
+    if (word === word.toUpperCase() && word.length > 1) {
+      const filenameInHeading = new RegExp(`\\b${word}\\.[a-zA-Z]+\\b`);
+      if (filenameInHeading.test(headingText)) {
+        continue;
+      }
+    }
+
     // Check general lowercase requirement
     if (
       word !== word.toLowerCase() &&

--- a/tests/features/false-positive-agent-playbook.test.js
+++ b/tests/features/false-positive-agent-playbook.test.js
@@ -231,6 +231,23 @@ describe('Sentence-case false positives from agent-playbook', () => {
       const errors = await lintWithRule(content, sentenceCaseHeading);
       expect(errors).toHaveLength(0);
     });
+
+    test('ALL-CAPS filename as non-first word should not be flagged', async () => {
+      const cases = [
+        { heading: '## About the LICENSE.md terms', word: 'LICENSE' },
+        { heading: '## Edit CONTRIBUTING.md now', word: 'CONTRIBUTING' },
+        { heading: '## See the SECURITY.md policy', word: 'SECURITY' },
+        { heading: '## Update your SKILL.md file', word: 'SKILL' },
+      ];
+
+      for (const { heading, word } of cases) {
+        const errors = await lintWithRule(heading, sentenceCaseHeading);
+        const filenameErrors = errors.filter(e =>
+          e.errorDetail && e.errorDetail.includes(`"${word}"`)
+        );
+        expect(filenameErrors).toHaveLength(0);
+      }
+    });
   });
 
   describe('file paths should preserve original casing', () => {


### PR DESCRIPTION
Closes #158

## Summary

- Fix SC001 false positive where ALL-CAPS filenames (e.g., `LICENSE.md`, `CONTRIBUTING.md`, `SKILL.md`) appearing as non-first words in headings were flagged as needing lowercase
- The existing exemption in `shouldExemptFromValidation` only checked the first word; after the `clean` step strips dots, words like `LICENSE` from `LICENSE.md` were split and flagged by `validateSubsequentWords`
- Added a check in `validateSubsequentWords` to detect when an ALL-CAPS word was part of a filename in the original heading text before dot removal

## Test plan

- [x] Added failing test for ALL-CAPS filenames as non-first words (LICENSE.md, CONTRIBUTING.md, SECURITY.md, SKILL.md)
- [x] Verified test fails before fix (red)
- [x] Implemented minimal fix in `validateSubsequentWords`
- [x] `npm run validate` passes (1410 tests, 0 failures)