### PR TITLE
fix: treat skills/skill as common words

### DIFF
--- a/src/rules/shared-constants.js
+++ b/src/rules/shared-constants.js
@@ -517,14 +517,6 @@ export const ambiguousTerms = {
     properForm: 'Edge',
     reason: 'Could be noun "edge" OR Microsoft Edge (the browser)'
   },
-  skills: {
-    properForm: 'Skills',
-    reason: 'Could be common noun "skills" OR Claude Skills feature'
-  },
-  skill: {
-    properForm: 'Skill',
-    reason: 'Could be common noun "skill" OR Claude Skill feature'
-  },
   agent: {
     properForm: 'Agent',
     reason: 'Could be common noun "agent" OR Claude Agent feature/SDK'

--- a/tests/features/false-positive-audit-round6.test.js
+++ b/tests/features/false-positive-audit-round6.test.js
@@ -65,8 +65,8 @@ describe('False positive fixes - Round 6', () => {
     });
   });
 
-  describe('sentence-case-heading (SC001) - Skills as proper noun', () => {
-    test('should NOT flag "Skills" when referring to Claude Skills feature', async () => {
+  describe('sentence-case-heading (SC001) - skills as common word (#157)', () => {
+    test('should flag "Skills" (capitalized) as a common word needing lowercase', async () => {
       const input = [
         '## The Skills architecture',
         '## Where Skills work',
@@ -83,7 +83,7 @@ describe('False positive fixes - Round 6', () => {
         customRules: [sentenceCaseHeading],
       });
 
-      expect(result.input).toHaveLength(0);
+      expect(result.input).toHaveLength(4);
     });
 
     test('should NOT flag "Agent Skills" as a compound proper noun', async () => {

--- a/tests/unit/sentence-case-classifier.test.js
+++ b/tests/unit/sentence-case-classifier.test.js
@@ -10,6 +10,10 @@ import {
   isAllCapsHeading,
   stripLeadingSymbols,
 } from "../../src/rules/sentence-case/case-classifier.js";
+import {
+  ambiguousTerms,
+  casingTerms,
+} from "../../src/rules/shared-constants.js";
 
 describe("stripLeadingSymbols", () => {
   test("test_should_remove_single_emoji_from_start_of_text", () => {
@@ -352,6 +356,16 @@ describe("validateHeading", () => {
     const result = validateHeading(text, defaultSpecialTerms);
     expect(result.isValid).toBe(false);
   });
+
+  test("treats 'skills' as a regular lowercase word (#157)", () => {
+    const result = validateHeading("Code skills", defaultSpecialTerms);
+    expect(result.isValid).toBe(true);
+  });
+
+  test("treats 'skill' as a regular lowercase word (#157)", () => {
+    const result = validateHeading("Agent skill overview", defaultSpecialTerms);
+    expect(result.isValid).toBe(true);
+  });
 });
 
 describe("validateBoldText", () => {
@@ -434,5 +448,33 @@ describe("validateBoldText", () => {
   test("test_should_handle_empty_bold_text", () => {
     const result = validateBoldText("", defaultSpecialTerms);
     expect(result.isValid).toBe(true); // Empty text should not error
+  });
+
+  test("treats 'skills' as a regular lowercase word in bold (#157)", () => {
+    const result = validateBoldText("Use skills", defaultSpecialTerms);
+    expect(result.isValid).toBe(true);
+  });
+
+  test("treats 'skill' as a regular lowercase word in bold (#157)", () => {
+    const result = validateBoldText("Analysis skill", defaultSpecialTerms);
+    expect(result.isValid).toBe(true);
+  });
+});
+
+describe("issue #157: skills/skill not in special dictionaries", () => {
+  test("'skills' is not in ambiguousTerms", () => {
+    expect(ambiguousTerms).not.toHaveProperty("skills");
+  });
+
+  test("'skill' is not in ambiguousTerms", () => {
+    expect(ambiguousTerms).not.toHaveProperty("skill");
+  });
+
+  test("'skills' is not in casingTerms", () => {
+    expect(casingTerms).not.toHaveProperty("skills");
+  });
+
+  test("'skill' is not in casingTerms", () => {
+    expect(casingTerms).not.toHaveProperty("skill");
   });
 });


### PR DESCRIPTION
## Summary

- Remove "skills" and "skill" from `ambiguousTerms` dictionary since they are common English nouns, not product-specific proper nouns
- "Agent Skills" (the compound phrase) remains as a proper noun in `casingTerms`
- Add unit tests validating headings and bold text with "skills"/"skill" pass without errors

Closes #157

## Test plan

- [x] Unit tests for `validateHeading` with "Code skills", "Agent skill overview"
- [x] Unit tests for `validateBoldText` with "Use skills", "Analysis skill"
- [x] Dictionary tests confirming skills/skill removed from ambiguousTerms and casingTerms
- [x] Existing false-positive audit test updated to expect correct behavior
- [x] `npm run validate` passes