### PR TITLE
fix: detect tilde-prefixed paths as units

### DIFF
--- a/src/rules/backtick-code-elements.js
+++ b/src/rules/backtick-code-elements.js
@@ -615,6 +615,9 @@ function backtickCodeElements(params, onError) {
       //   [\w.-]+        - Final segment (filename or directory)
       //   (?=\s|$)       - Followed by whitespace or end of line (lookahead)
       /(?:^|(?<=\s))\/(?:[\w.-]+\/)*[\w.-]+(?=\s|$)/g,
+      // Issue #162: Tilde-prefixed home directory paths like ~/.claude/skills, ~/Documents
+      // Must be checked BEFORE dir/dotfile patterns to capture the full path as one unit
+      /(?:^|(?<=\s))~\/(?:[\w.-]+\/)*[\w.-]+/g,
       /\b(?:\.?\/?[\w.-]+\/)+[\w.-]+\b/g, // directory or file path
       /\b(?=[^\d\s])[\w.-]*[a-zA-Z][\w.-]*\.[a-zA-Z0-9]{1,5}\b/g, // file name with letters
       /\b[a-zA-Z][\w.-]*\([^)]*\)/g,       // simple function or command()


### PR DESCRIPTION
Closes #162

## Summary

- Add tilde-path regex pattern that matches `~/...` paths as complete units (e.g., `~/.claude/skills`, `~/Documents/file.txt`)
- Pattern is placed before dir/dotfile patterns so it captures the full path first, preventing partial matches via flaggedRanges overlap detection
- Previously, `~/.claude` was flagged as just `.claude` (dotfile), and `~/Documents/file.txt` was flagged as `Documents/file.txt` (missing `~/` prefix)

## Test plan

- [x] Test: `~/.claude` is flagged as full path `~/.claude`, not as dotfile `.claude`
- [x] Test: `~/Documents/file.txt` is flagged as the complete tilde path
- [x] All feature tests pass (768/768)
- [x] Pre-push checks pass on all three remotes