### PR TITLE
fix: exclude English prefixes from acronym detection

### DIFF
--- a/src/rules/sentence-case/case-classifier.js
+++ b/src/rules/sentence-case/case-classifier.js
@@ -368,7 +368,9 @@ function validateFirstWord(firstWord, firstIndex, phraseIgnore, specialCasedTerm
           // Technical compound words (not acronyms)
           'rule', 'user', 'file', 'line', 'code', 'auto', 'type', 'real', 'open',
           'zero', 'data', 'test', 'back', 'side', 'case', 'base', 'next', 'last',
-          'osv', 'npm', 'cli', 'api'  // Tool/tech names used as prefixes
+          'osv', 'npm', 'cli', 'api',  // Tool/tech names used as prefixes
+          // Standard English prefixes (#159)
+          'semi', 'mega', 'mini', 'mono', 'poly', 'para', 'meta'
         ];
         if (possibleAcronym.length >= 2 && possibleAcronym.length <= 4 &&
             !commonHyphenatedPrefixes.includes(possibleAcronym.toLowerCase())) {

--- a/tests/unit/sentence-case-classifier.test.js
+++ b/tests/unit/sentence-case-classifier.test.js
@@ -478,3 +478,39 @@ describe("issue #157: skills/skill not in special dictionaries", () => {
     expect(casingTerms).not.toHaveProperty("skill");
   });
 });
+
+describe("issue #159: common English prefixes not flagged as acronyms", () => {
+  const defaultSpecialTerms = { api: "API", rest: "REST" };
+
+  test.each([
+    ["Auto-update", "auto"],
+    ["Semi-automatic", "semi"],
+    ["Mega-pixel", "mega"],
+    ["Mini-batch", "mini"],
+    ["Mono-repo", "mono"],
+    ["Poly-morphic", "poly"],
+    ["Para-normal", "para"],
+  ])("heading starting with %s is valid (prefix: %s)", (compound) => {
+    const result = validateHeading(`${compound} mode`, defaultSpecialTerms);
+    expect(result.isValid).toBe(true);
+  });
+
+  test.each([
+    ["Auto-update", "auto"],
+    ["Semi-automatic", "semi"],
+    ["Mega-pixel", "mega"],
+    ["Mini-batch", "mini"],
+    ["Mono-repo", "mono"],
+    ["Poly-morphic", "poly"],
+    ["Para-normal", "para"],
+  ])("bold text starting with %s is valid (prefix: %s)", (compound) => {
+    const result = validateBoldText(`${compound} mode`, defaultSpecialTerms);
+    expect(result.isValid).toBe(true);
+  });
+
+  test("still flags actual misspelled acronyms like Yaml-based", () => {
+    const result = validateHeading("Yaml-based config", defaultSpecialTerms);
+    expect(result.isValid).toBe(false);
+    expect(result.errorMessage).toMatch(/YAML/);
+  });
+});


### PR DESCRIPTION
## Summary

- Add common English prefixes (`semi`, `mega`, `mini`, `mono`, `poly`, `para`, `meta`) to the acronym-prefix exclusion list in `case-classifier.js`
- The acronym-prefix heuristic (lines 354-380) was incorrectly matching title-cased English prefixes like "Semi-", "Mega-", "Mini-" as misspelled acronyms and suggesting all-caps forms
- "Auto-" was already excluded; this extends coverage to other standard English prefixes

Closes #159

## Test plan

- [x] Unit tests for `validateHeading` with all 7 prefix compounds (Auto, Semi, Mega, Mini, Mono, Poly, Para)
- [x] Unit tests for `validateBoldText` with same 7 prefix compounds
- [x] Regression test ensuring "Yaml-based" is still flagged as a misspelled acronym
- [x] Full test suite passes (96/96 classifier tests, 1412/1412 overall)