### PR TITLE
Split SC001 specialTerms into acronyms vs properNouns

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,8 @@ A consumer repo's `.markdownlint-cli2.jsonc` should extend the preset and add on
     "extends": "markdownlint-trap/recommended-config.jsonc",
     // Repo-specific overrides below
     "sentence-case-heading": {
-      "specialTerms": ["AcmeKey", "Okta"]
+      "acronyms": ["SSO", "OIDC"],
+      "properNouns": ["Acme", "Okta"]
     }
   }
 }
@@ -94,8 +95,9 @@ flowchart TD
 
 ## `sentence-case-heading` (SC001)
 
-- `specialTerms`: string[] — Proper nouns and technical terms to preserve as-is.
-- Deprecated: `technicalTerms`, `properNouns` — Use `specialTerms` instead.
+- `acronyms`: string[] — Acronyms that must be uppercase. The lowercase or mixed-case form is flagged and fixed to the configured uppercase form (e.g. `cefr` → `CEFR`).
+- `properNouns`: string[] — Proper nouns whose capitalized form is allowed. The lowercase common-word homograph is **not** flagged, so adding `Craft` permits both `Craft` and the everyday word `craft`.
+- Deprecated: `specialTerms` — Alias for `properNouns`; existing configs keep working. `technicalTerms` is also deprecated. Prefer `acronyms` for terms that must be uppercase and `properNouns` for terms that merely allow a capitalized form.
 
 Defaults: Built-in dictionary of proper nouns and tech terms covers most teams. Fixable: Yes.
 
@@ -234,4 +236,6 @@ Deprecated options and their replacements:
 
 | Rule | Deprecated | Replacement |
 |------|------------|-------------|
-| `sentence-case-heading` | `technicalTerms`, `properNouns` | `specialTerms` |
+| `sentence-case-heading` | `specialTerms`, `technicalTerms` | `acronyms` (must be uppercase) and `properNouns` (capitalized form allowed) |
+
+`specialTerms` forced casing both ways — adding a proper noun to allow its capitalized form also flagged the lowercase homograph. Split terms into `acronyms` for casing that is required and `properNouns` for casing that is merely allowed. `specialTerms` continues to work as a deprecated alias for `properNouns`.

--- a/recommended-config.jsonc
+++ b/recommended-config.jsonc
@@ -17,12 +17,16 @@
 
     // Enable custom rules from this package
     "sentence-case-heading": {
-      "specialTerms": [
-        // Common acronyms
+      // Acronyms must be uppercase; the lowercase form is flagged and fixed.
+      "acronyms": [
         "LLM",
         "NAS",
         "PDF",
         "UX",
+        "NOTE"
+      ],
+      // Proper nouns allow a capitalized form without flagging a lowercase homograph.
+      "properNouns": [
         // Major platforms
         "Google Drive",
         "Google Workspace",
@@ -34,9 +38,7 @@
         "MacBook",
         "MacBook Air",
         // GitHub products
-        "GitHub Codespaces",
-        // Emphasis terms
-        "NOTE"
+        "GitHub Codespaces"
       ]
     },
     "backtick-code-elements": true,

--- a/scripts/generate-config-docs.js
+++ b/scripts/generate-config-docs.js
@@ -88,20 +88,26 @@ const RULE_METADATA = {
  * Configuration option metadata
  */
 const CONFIG_OPTION_METADATA = {
+  acronyms: {
+    type: 'string[]',
+    description: 'Acronyms that must be uppercase. The lowercase or mixed-case form is flagged and fixed to the configured uppercase form',
+    default: '[]',
+    example: '["API", "CEFR", "WYSIWYG"]'
+  },
+  properNouns: {
+    type: 'string[]',
+    description: 'Proper nouns whose capitalized form is allowed. The lowercase common-word homograph (e.g. "craft" for "Craft") is NOT flagged',
+    default: '[]',
+    example: '["Craft", "Node", "Timing"]'
+  },
   specialTerms: {
     type: 'string[]',
-    description: 'Terms that should maintain their exact casing in headings',
-    default: '["API", "APIs", "CSS", "HTML", "HTTP", "HTTPS", "JavaScript", "JSON", "REST", "SDK", "SQL", "URL", "URLs", "XML"]',
-    example: '["API", "GitHub", "OAuth"]'
+    description: '**Deprecated**: Alias for `properNouns`. Use `properNouns` for allowed-capitalization terms or `acronyms` for terms that must be uppercase',
+    deprecated: true
   },
   technicalTerms: {
     type: 'string[]',
-    description: '**Deprecated**: Use `specialTerms` instead',
-    deprecated: true
-  },
-  properNouns: {
-    type: 'string[]', 
-    description: '**Deprecated**: Use `specialTerms` instead',
+    description: '**Deprecated**: Use `acronyms` or `properNouns` instead',
     deprecated: true
   },
   ignoredTerms: {
@@ -426,15 +432,20 @@ Some configuration options have been deprecated in favor of more consistent nami
 
 | Rule | Deprecated Option | New Option | Migration |
 |------|------------------|------------|-----------|
-| \`sentence-case-heading\` | \`technicalTerms\` | \`specialTerms\` | Rename the option |
-| \`sentence-case-heading\` | \`properNouns\` | \`specialTerms\` | Rename the option |
+| \`sentence-case-heading\` | \`specialTerms\` | \`acronyms\` / \`properNouns\` | Split terms by whether they must be uppercase (acronyms) or merely allow a capitalized form (proper nouns) |
+| \`sentence-case-heading\` | \`technicalTerms\` | \`acronyms\` / \`properNouns\` | Same split as above |
+
+\`specialTerms\` (and the older \`technicalTerms\`) forced casing both ways: adding a
+proper noun to allow its capitalized form also flagged the legitimate lowercase
+homograph. The split separates "casing that is required" (\`acronyms\`) from
+"casing that is allowed" (\`properNouns\`). \`specialTerms\` continues to work as a
+deprecated alias for \`properNouns\`.
 
 **Before:**
 \`\`\`json
 {
   "sentence-case-heading": {
-    "technicalTerms": ["API", "REST"],
-    "properNouns": ["GitHub", "OAuth"]
+    "specialTerms": ["API", "CEFR", "Craft", "Node"]
   }
 }
 \`\`\`
@@ -443,7 +454,8 @@ Some configuration options have been deprecated in favor of more consistent nami
 \`\`\`json
 {
   "sentence-case-heading": {
-    "specialTerms": ["API", "REST", "GitHub", "OAuth"]
+    "acronyms": ["API", "CEFR"],
+    "properNouns": ["Craft", "Node"]
   }
 }
 \`\`\`

--- a/src/rules/sentence-case-heading.js
+++ b/src/rules/sentence-case-heading.js
@@ -4,17 +4,26 @@
  * Custom markdownlint rule that enforces sentence case for headings.
  *
  * Configuration:
- * - specialTerms: Array of terms with specific capitalization (e.g., ["JavaScript", "API", "GitHub"])
+ * - acronyms: Array of acronyms that must be uppercase (e.g., ["API", "CEFR",
+ *   "WYSIWYG"]). The lowercase or mixed-case form is flagged and fixed to the
+ *   configured uppercase form.
+ * - properNouns: Array of proper nouns whose capitalized form is allowed
+ *   (e.g., ["Craft", "Node", "Timing"]). The lowercase common-word homograph
+ *   (e.g. "craft", "node") is NOT flagged, so a proper noun and its everyday
+ *   lowercase usage can coexist without whack-a-mole configuration.
  * - ignoreAfterEmoji: Boolean to ignore text after the first emoji (default: false)
  *
- * Deprecated (use specialTerms instead):
- * - technicalTerms: Legacy option, use specialTerms
- * - properNouns: Legacy option, use specialTerms
+ * Deprecated:
+ * - specialTerms: Alias for `properNouns`. Retained for backward compatibility;
+ *   prefer `properNouns` for allowed-capitalization terms and `acronyms` for
+ *   terms that must be uppercase.
+ * - technicalTerms: Legacy forcing option; prefer `acronyms` or `properNouns`.
  *
  * Example configuration:
  * {
  *   "sentence-case-heading": {
- *     "specialTerms": ["JavaScript", "TypeScript", "API", "GitHub", "OAuth"],
+ *     "acronyms": ["API", "CEFR", "WYSIWYG"],
+ *     "properNouns": ["Craft", "Node", "Timing"],
  *     "ignoreAfterEmoji": true
  *   }
  * }
@@ -69,9 +78,10 @@ function basicSentenceCaseHeadingFunction(params, onError) {
 
   // Validate configuration
   const configSchema = {
+    acronyms: validateStringArray,
+    properNouns: validateStringArray,
     specialTerms: validateStringArray,
     technicalTerms: validateStringArray,
-    properNouns: validateStringArray,
     ignoreAfterEmoji: validateBoolean
   };
 
@@ -86,26 +96,42 @@ function basicSentenceCaseHeadingFunction(params, onError) {
   // Get ignoreAfterEmoji option (default: false for backward compatibility)
   const ignoreAfterEmoji = typeof config.ignoreAfterEmoji === 'boolean' ? config.ignoreAfterEmoji : false;
 
-  // Support both new `specialTerms` and old `technicalTerms`/`properNouns` for user config
-  // Only use valid arrays; fall back to empty arrays for invalid config
+  // Term routing (#233):
+  // - acronyms: must be uppercase. Registered as forcing terms in
+  //   specialCasedTerms so the lowercase/mixed form is flagged and fixed.
+  // - properNouns: the capitalized form is allowed, but the lowercase
+  //   common-word homograph must NOT be flagged. The canonical casing is
+  //   registered in specialCasedTerms (so the capitalized form and multi-word
+  //   phrases are recognized) AND the lowercase single-word key is registered
+  //   as an "allowed both ways" term so the homograph passes.
+  // - specialTerms: deprecated alias for properNouns (backward compatibility).
+  // - technicalTerms: legacy forcing option, treated like acronyms.
+  // Only use valid arrays; fall back to empty arrays for invalid config.
+  const userAcronyms = Array.isArray(config.acronyms) ? config.acronyms : [];
+  const userProperNouns = Array.isArray(config.properNouns) ? config.properNouns : [];
   const userSpecialTerms = Array.isArray(config.specialTerms) ? config.specialTerms : [];
   const userTechnicalTerms = Array.isArray(config.technicalTerms) ? config.technicalTerms : [];
-  const userProperNouns = Array.isArray(config.properNouns) ? config.properNouns : [];
-  
-  // Show deprecation warnings for old configuration keys
+
+  // Show deprecation warnings for old configuration keys.
   // Note: These are deprecation warnings (not configuration errors), using console.warn
   // to maintain compatibility with existing tooling that may capture console output.
   // These warnings are informational and don't prevent the rule from functioning.
+  if (config.specialTerms && Array.isArray(config.specialTerms) && config.specialTerms.length > 0 && !_deprecationWarned.has('specialTerms')) {
+    _deprecationWarned.add('specialTerms');
+    console.warn('⚠️  Deprecation warning [sentence-case-heading]: "specialTerms" is deprecated. Use "properNouns" for allowed-capitalization terms or "acronyms" for terms that must be uppercase.');
+  }
   if (config.technicalTerms && Array.isArray(config.technicalTerms) && config.technicalTerms.length > 0 && !_deprecationWarned.has('technicalTerms')) {
     _deprecationWarned.add('technicalTerms');
-    console.warn('⚠️  Deprecation warning [sentence-case-heading]: "technicalTerms" is deprecated. Please use "specialTerms" instead.');
+    console.warn('⚠️  Deprecation warning [sentence-case-heading]: "technicalTerms" is deprecated. Use "acronyms" or "properNouns" instead.');
   }
-  if (config.properNouns && Array.isArray(config.properNouns) && config.properNouns.length > 0 && !_deprecationWarned.has('properNouns')) {
-    _deprecationWarned.add('properNouns');
-    console.warn('⚠️  Deprecation warning [sentence-case-heading]: "properNouns" is deprecated. Please use "specialTerms" instead.');
-  }
-  
-  const allUserTerms = [...userSpecialTerms, ...userTechnicalTerms, ...userProperNouns];
+
+  // Forcing terms: acronyms and the legacy technicalTerms enforce exact casing.
+  const forcingTerms = [...userAcronyms, ...userTechnicalTerms];
+  // Allowed-both-ways terms: properNouns and the deprecated specialTerms alias.
+  const allowedTerms = [...userProperNouns, ...userSpecialTerms];
+  // Every user term still seeds specialCasedTerms so the canonical capitalized
+  // form (and multi-word phrases) are recognized and never lowercased.
+  const allUserTerms = [...forcingTerms, ...allowedTerms];
 
   // Memoize specialCasedTerms: spreading defaultCasingTerms (~390 entries) is O(n) per
   // invocation. Cache keyed on sorted user terms so lint runs over many files pay the
@@ -123,6 +149,29 @@ function basicSentenceCaseHeadingFunction(params, onError) {
       }
     });
     _specialCasedTermsCache.set(cacheKey, specialCasedTerms);
+  }
+
+  // Build the effective "allowed both ways" map: built-in ambiguous terms plus
+  // single-word proper nouns (and specialTerms alias). A proper noun registered
+  // here lets both its capitalized form and its lowercase homograph pass (#233).
+  // Multi-word proper nouns ("Claude Code") are left to specialCasedTerms phrase
+  // matching, since the allowed-both-ways skip only applies to single tokens.
+  let effectiveAmbiguousTerms = ambiguousTerms;
+  const allowedSingleWords = allowedTerms.filter(
+    (t) => typeof t === 'string' && !t.includes(' ')
+  );
+  if (allowedSingleWords.length > 0) {
+    effectiveAmbiguousTerms = { ...ambiguousTerms };
+    allowedSingleWords.forEach((term) => {
+      const key = term.toLowerCase();
+      // Do not override a built-in ambiguous entry.
+      if (!effectiveAmbiguousTerms[key]) {
+        effectiveAmbiguousTerms[key] = {
+          properForm: term,
+          reason: 'User-configured proper noun (allowed capitalized; lowercase homograph not flagged)'
+        };
+      }
+    });
   }
 
   const safetyConfig = params.config?.autofix?.safety || {};
@@ -150,7 +199,7 @@ function basicSentenceCaseHeadingFunction(params, onError) {
       lineNumber,
       detail,
       context: headingText,
-      fixInfo: buildHeadingFix(line, fixTarget, specialCasedTerms, safetyConfig, ambiguousTerms)
+      fixInfo: buildHeadingFix(line, fixTarget, specialCasedTerms, safetyConfig, effectiveAmbiguousTerms)
     });
   }
 
@@ -165,7 +214,7 @@ function basicSentenceCaseHeadingFunction(params, onError) {
   function reportForBoldText(detail, lineNumber, boldText, line, textForValidation) {
     // If ignoreAfterEmoji is enabled and text was truncated, only fix the part before emoji
     const fixTarget = (ignoreAfterEmoji && textForValidation) ? textForValidation : boldText;
-    const fixedText = toSentenceCase(fixTarget, specialCasedTerms, ambiguousTerms);
+    const fixedText = toSentenceCase(fixTarget, specialCasedTerms, effectiveAmbiguousTerms);
 
     onError({
       lineNumber,
@@ -194,7 +243,7 @@ function basicSentenceCaseHeadingFunction(params, onError) {
     // Apply ignoreAfterEmoji truncation if enabled
     const { textForValidation } = truncateAtEmoji(boldText, ignoreAfterEmoji);
 
-    const validationResult = validateBoldText(textForValidation, specialCasedTerms, ambiguousTerms);
+    const validationResult = validateBoldText(textForValidation, specialCasedTerms, effectiveAmbiguousTerms);
 
     if (!validationResult.isValid) {
       reportForBoldText(validationResult.errorMessage, lineNumber, boldText, sourceLine, textForValidation);
@@ -217,7 +266,7 @@ function basicSentenceCaseHeadingFunction(params, onError) {
     // Apply ignoreAfterEmoji truncation if enabled
     const { textForValidation } = truncateAtEmoji(headingText, ignoreAfterEmoji);
 
-    const validationResult = validateHeading(textForValidation, specialCasedTerms, ambiguousTerms);
+    const validationResult = validateHeading(textForValidation, specialCasedTerms, effectiveAmbiguousTerms);
 
     if (!validationResult.isValid) {
       // Use cleanedText (emoji stripped) for error context to match original behavior

--- a/src/rules/sentence-case/bold-text-classifier.js
+++ b/src/rules/sentence-case/bold-text-classifier.js
@@ -20,6 +20,54 @@ import {
 } from './case-classifier.js';
 
 /**
+ * Determines whether a hyphenated compound is acceptable in bold text because
+ * every segment is individually valid: a lowercase word, the pronoun "I", a
+ * short acronym, or a segment whose uppercased form is a configured acronym or
+ * special term (e.g. "high-CEFR", "FAQ-shaped", "API-wide"). At least one
+ * segment must be a configured term or acronym so ordinary mixed-case compounds
+ * like "Bad-Word" are still flagged (#233 Part B.2).
+ * @param {string} word The hyphenated token to check.
+ * @param {Object} specialCasedTerms Special casing terms dictionary.
+ * @returns {boolean} True when the compound should be left alone.
+ */
+function isAcceptableHyphenatedCompound(word, specialCasedTerms) {
+  if (!word.includes('-')) {
+    return false;
+  }
+  const segments = word.split('-');
+  if (segments.length < 2) {
+    return false;
+  }
+
+  let sawConfiguredOrAcronym = false;
+  for (const segment of segments) {
+    if (segment === '') {
+      return false;
+    }
+    // Plain lowercase segment is always acceptable.
+    if (segment === segment.toLowerCase()) {
+      continue;
+    }
+    // A segment matching a configured term's exact casing (acronym or proper
+    // noun) is acceptable, e.g. "CEFR", "FAQ", "API", "Saxon".
+    const configured = specialCasedTerms[segment.toLowerCase()];
+    if (configured && segment === configured) {
+      sawConfiguredOrAcronym = true;
+      continue;
+    }
+    // A short all-caps acronym is acceptable even when not explicitly configured.
+    if (isAcronym(segment)) {
+      sawConfiguredOrAcronym = true;
+      continue;
+    }
+    // Any other non-lowercase segment (e.g. "Bad", "Word") is a violation.
+    return false;
+  }
+
+  return sawConfiguredOrAcronym;
+}
+
+/**
  * Performs stricter validation for bold text in list items.
  * @param {string[]} words Array of words to validate.
  * @param {string} cleanedText The cleaned text.
@@ -89,6 +137,12 @@ export function performBoldTextValidation(words, cleanedText, hadLeadingEmoji, s
       continue;
     }
 
+    // A hyphenated special term (e.g. "Anglo-Saxon") matches as a whole token, so
+    // no sub-segment is independently checked for lowercase casing (#233 Part B.2).
+    if (expectedWordCasing && word === expectedWordCasing && word.includes('-')) {
+      continue;
+    }
+
     // For bold text, be stricter about acronyms - only allow known technical terms
     if (expectedWordCasing) {
       // Known proper noun or technical term
@@ -138,6 +192,25 @@ export function performBoldTextValidation(words, cleanedText, hadLeadingEmoji, s
         ];
 
         if (!allowedCapitalizedWords.includes(word)) {
+          // Exempt digit-bearing tokens that are NOT title-cased words: units,
+          // versions, and all-caps product names ("25KB", "BCE-500", "PM2") are
+          // not subject to the all-caps or lowercase checks. This mirrors the
+          // heading path's digit exemption, which was missing here (#233 Part B.1).
+          // A title-cased word with an incidental digit ("Database2") still falls
+          // through to the checks below.
+          if (/\d/.test(word) && !/^[A-Z][a-z]/.test(word)) {
+            continue;
+          }
+
+          // A hyphenated compound is acceptable when every segment is itself
+          // acceptable: a lowercase word or a segment whose uppercased form is a
+          // configured acronym / special term (e.g. "high-CEFR", "FAQ-shaped",
+          // "API-wide"). This whole-token reasoning previously only ran on the
+          // heading path (#233 Part B.2).
+          if (word.includes('-') && isAcceptableHyphenatedCompound(word, specialCasedTerms)) {
+            continue;
+          }
+
           // Check for all-caps violations (but allow known acronyms from specialCasedTerms)
           if (word === word.toUpperCase() && word.length > 1 && UNICODE_UPPERCASE_REGEX.test(word) && !expectedWordCasing) {
             return {
@@ -159,6 +232,15 @@ export function performBoldTextValidation(words, cleanedText, hadLeadingEmoji, s
 
     // Check hyphenated words
     if (word.includes('-')) {
+      // Whole-token special-term and acceptable-compound matches already passed
+      // above; skip the per-segment lowercase check for those (#233 Part B.2).
+      if (expectedWordCasing && word === expectedWordCasing) {
+        continue;
+      }
+      if (isAcceptableHyphenatedCompound(word, specialCasedTerms)) {
+        continue;
+      }
+
       const parts = word.split('-');
       if (parts.length > 1 && parts[1] !== parts[1].toLowerCase()) {
         return {

--- a/tests/features/sentence-case-acronyms-propernouns.test.js
+++ b/tests/features/sentence-case-acronyms-propernouns.test.js
@@ -1,0 +1,92 @@
+// @ts-check
+
+/**
+ * Feature tests for the SC001 specialTerms redesign (issue #233).
+ *
+ * Splits the single overloaded "specialTerms" concept into:
+ * - acronyms: must be uppercase (the lowercase/mixed form is flagged)
+ * - properNouns: the capitalized form is allowed, but the lowercase
+ *   common-word homograph is NOT flagged
+ *
+ * "specialTerms" is retained as a deprecated alias for properNouns so that
+ * existing configurations keep working.
+ */
+
+import { describe, test, expect } from '@jest/globals';
+import { lint } from 'markdownlint/promise';
+import sentenceRule from '../../src/rules/sentence-case-heading.js';
+
+/**
+ * Lint markdown content with the SC001 rule and a given config.
+ * @param {string} content Markdown content to lint.
+ * @param {Object} config sentence-case-heading configuration.
+ * @returns {Promise<object[]>} SC001 violations with fixInfo (actual errors).
+ */
+async function lintMarkdown(content, config = {}) {
+  const options = {
+    customRules: [sentenceRule],
+    strings: { testContent: content },
+    config: {
+      default: false,
+      'sentence-case-heading': config
+    },
+    resultVersion: 3
+  };
+  const results = await lint(options);
+  return (results.testContent || []).filter(
+    (v) =>
+      (v.ruleNames.includes('sentence-case-heading') ||
+        v.ruleNames.includes('SC001')) &&
+      v.fixInfo != null
+  );
+}
+
+describe('SC001 properNouns (issue #233)', () => {
+  test('test_should_allow_capitalized_proper_noun_when_configured', async () => {
+    const violations = await lintMarkdown('# Craft tasks', { properNouns: ['Craft'] });
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_lowercase_homograph_when_proper_noun_configured', async () => {
+    const violations = await lintMarkdown('# Word craft basics', { properNouns: ['Craft'] });
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_allow_proper_noun_mid_heading_in_either_case', async () => {
+    const lower = await lintMarkdown('# A node in the graph', { properNouns: ['Node'] });
+    const upper = await lintMarkdown('# Working with Node', { properNouns: ['Node'] });
+    expect(lower).toHaveLength(0);
+    expect(upper).toHaveLength(0);
+  });
+});
+
+describe('SC001 acronyms (issue #233)', () => {
+  test('test_should_flag_lowercase_acronym_to_uppercase', async () => {
+    const violations = await lintMarkdown('# Mapping cefr levels', { acronyms: ['CEFR'] });
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0].errorDetail).toMatch(/CEFR/);
+  });
+
+  test('test_should_allow_uppercase_acronym_when_configured', async () => {
+    const violations = await lintMarkdown('# Mapping CEFR levels', { acronyms: ['CEFR'] });
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_flag_lowercase_multiletter_acronym', async () => {
+    const violations = await lintMarkdown('# A wysiwyg editor', { acronyms: ['WYSIWYG'] });
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0].errorDetail).toMatch(/WYSIWYG/);
+  });
+});
+
+describe('SC001 specialTerms deprecated alias (issue #233)', () => {
+  test('test_should_treat_special_terms_as_proper_nouns_allowing_capitalized', async () => {
+    const violations = await lintMarkdown('# Acme widget overview', { specialTerms: ['Acme'] });
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_lowercase_homograph_via_special_terms_alias', async () => {
+    const violations = await lintMarkdown('# Working on a foobar', { specialTerms: ['Foobar'] });
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/tests/features/sentence-case-config-validation.test.js
+++ b/tests/features/sentence-case-config-validation.test.js
@@ -82,6 +82,26 @@ describe('sentence-case-heading configuration validation', () => {
       expect(mockConsoleError).not.toHaveBeenCalled();
     });
 
+    test('accepts valid acronyms array', () => {
+      const config = {
+        acronyms: ['CEFR', 'WYSIWYG', 'API']
+      };
+
+      runRuleWithConfig(config);
+      expect(mockConsoleError).not.toHaveBeenCalled();
+    });
+
+    test('logs error for non-array acronyms', () => {
+      const config = {
+        acronyms: 'not an array'
+      };
+
+      const errors = runRuleWithConfig(config);
+      const configErrors = errors.filter(error => error.detail.includes('Configuration Error'));
+      expect(configErrors).toHaveLength(1);
+      expect(configErrors[0].detail).toContain('acronyms must be an array of strings');
+    });
+
     test('accepts valid specialTerms array', () => {
       const config = {
         specialTerms: ['iPhone', 'macOS', 'GitHub']
@@ -339,7 +359,7 @@ describe('sentence-case-heading configuration validation', () => {
       }
     });
 
-    test('shows warning for deprecated properNouns configuration', () => {
+    test('shows warning for deprecated specialTerms configuration', () => {
       const originalWarn = console.warn;
       const warnings = [];
       console.warn = (...args) => {
@@ -348,19 +368,19 @@ describe('sentence-case-heading configuration validation', () => {
 
       try {
         const config = {
-          properNouns: ["GitHub", "OAuth"]
+          specialTerms: ["GitHub", "OAuth"]
         };
 
         const markdown = '# Test heading';
         runRuleWithConfig(config, markdown);
 
-        expect(warnings.some(w => w.includes('properNouns" is deprecated'))).toBe(true);
+        expect(warnings.some(w => w.includes('specialTerms" is deprecated'))).toBe(true);
       } finally {
         console.warn = originalWarn;
       }
     });
 
-    test('does not show warnings for modern specialTerms configuration', () => {
+    test('does not warn for first-class properNouns configuration', () => {
       const originalWarn = console.warn;
       const warnings = [];
       console.warn = (...args) => {
@@ -369,7 +389,50 @@ describe('sentence-case-heading configuration validation', () => {
 
       try {
         const config = {
-          specialTerms: ["API", "GitHub"]
+          properNouns: ["Craft", "Node"]
+        };
+
+        const markdown = '# Test heading';
+        runRuleWithConfig(config, markdown);
+
+        expect(warnings.some(w => w.includes('properNouns" is deprecated'))).toBe(false);
+      } finally {
+        console.warn = originalWarn;
+      }
+    });
+
+    test('does not warn for first-class acronyms configuration', () => {
+      const originalWarn = console.warn;
+      const warnings = [];
+      console.warn = (...args) => {
+        warnings.push(args.join(' '));
+      };
+
+      try {
+        const config = {
+          acronyms: ["CEFR", "WYSIWYG"]
+        };
+
+        const markdown = '# Test heading';
+        runRuleWithConfig(config, markdown);
+
+        expect(warnings.some(w => w.includes('deprecated'))).toBe(false);
+      } finally {
+        console.warn = originalWarn;
+      }
+    });
+
+    test('does not show warnings for modern acronyms and properNouns configuration', () => {
+      const originalWarn = console.warn;
+      const warnings = [];
+      console.warn = (...args) => {
+        warnings.push(args.join(' '));
+      };
+
+      try {
+        const config = {
+          acronyms: ["API", "CEFR"],
+          properNouns: ["GitHub", "Craft"]
         };
 
         const markdown = '# Test heading';

--- a/tests/features/sentence-case-residual-false-positives.test.js
+++ b/tests/features/sentence-case-residual-false-positives.test.js
@@ -1,0 +1,100 @@
+// @ts-check
+
+/**
+ * Feature tests for residual SC001 false positives (issue #233, Part B).
+ *
+ * Two gaps remained after the earlier false-positive pass:
+ * 1. The "should not be in all caps" check did not exempt digit-bearing
+ *    tokens, so units/versions like "25KB", "BCE-500", and "PM2" were flagged.
+ * 2. The whole-hyphenated-token special-term match was only applied on the
+ *    heading path, so bold text still flagged hyphenated proper-noun and
+ *    acronym segments (e.g. "Anglo-Saxon" -> "Saxon").
+ */
+
+import { describe, test, expect } from '@jest/globals';
+import { lint } from 'markdownlint/promise';
+import sentenceRule from '../../src/rules/sentence-case-heading.js';
+
+/**
+ * Lint markdown content with the SC001 rule and a given config.
+ * @param {string} content Markdown content to lint.
+ * @param {Object} config sentence-case-heading configuration.
+ * @returns {Promise<object[]>} SC001 violations with fixInfo (actual errors).
+ */
+async function lintMarkdown(content, config = {}) {
+  const options = {
+    customRules: [sentenceRule],
+    strings: { testContent: content },
+    config: {
+      default: false,
+      'sentence-case-heading': config
+    },
+    resultVersion: 3
+  };
+  const results = await lint(options);
+  return (results.testContent || []).filter(
+    (v) =>
+      (v.ruleNames.includes('sentence-case-heading') ||
+        v.ruleNames.includes('SC001')) &&
+      v.fixInfo != null
+  );
+}
+
+describe('SC001 all-caps check exempts digit-bearing tokens (issue #233 Part B.1)', () => {
+  test('test_should_not_flag_size_token_in_bold', async () => {
+    const violations = await lintMarkdown('- **Under 200 lines and ~25KB** total');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_era_range_token_in_bold', async () => {
+    const violations = await lintMarkdown('- **Ancient history 3000 BCE-500 era** notes');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_versioned_product_token_in_bold', async () => {
+    const violations = await lintMarkdown('- **Running under PM2** for resilience');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_still_flag_genuine_all_caps_word_in_bold', async () => {
+    const violations = await lintMarkdown('- **Common PATTERNS reference** here');
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0].errorDetail).toMatch(/all caps|lowercase/i);
+  });
+});
+
+describe('SC001 hyphenated special-term match in bold text (issue #233 Part B.2)', () => {
+  test('test_should_not_flag_hyphenated_proper_noun_segment_in_bold', async () => {
+    const violations = await lintMarkdown('- **Latinate to Anglo-Saxon** shift', {
+      properNouns: ['Anglo-Saxon']
+    });
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_acronym_prefixed_hyphen_compound_in_bold', async () => {
+    const violations = await lintMarkdown('- **Targeting high-CEFR readers** first', {
+      acronyms: ['CEFR']
+    });
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_acronym_first_hyphen_compound_in_bold', async () => {
+    const violations = await lintMarkdown('- **A FAQ-shaped article** layout', {
+      acronyms: ['FAQ']
+    });
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_acronym_wide_hyphen_compound_in_bold', async () => {
+    const violations = await lintMarkdown('- **An API-wide convention** applies', {
+      acronyms: ['API']
+    });
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_still_flag_genuine_capitalized_hyphen_segment_in_bold', async () => {
+    const violations = await lintMarkdown('- **A Bad-Word example** here');
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0].errorDetail).toMatch(/lowercase/i);
+  });
+});

--- a/tests/unit/generate-config-docs.test.js
+++ b/tests/unit/generate-config-docs.test.js
@@ -345,13 +345,13 @@ describe('generate-config-docs', () => {
 
     test('should_skip_deprecated_options_in_example_config', () => {
       const schema = {
-        specialTerms: { type: 'string[]', validator: 'validateStringArray' },
-        technicalTerms: { type: 'string[]', validator: 'validateStringArray' }
+        acronyms: { type: 'string[]', validator: 'validateStringArray' },
+        specialTerms: { type: 'string[]', validator: 'validateStringArray' }
       };
       const doc = generateRuleDoc('sentence-case-heading', schema, '', ['sentence-case-heading']);
-      // technicalTerms is deprecated, should not appear in example config values
-      // but specialTerms should appear with its example
-      expect(doc).toContain('"specialTerms"');
+      // specialTerms is deprecated, should not appear in example config values
+      // but acronyms (first-class) should appear with its example
+      expect(doc).toContain('"acronyms"');
     });
 
     test('should_handle_option_with_no_metadata', () => {
@@ -409,7 +409,12 @@ describe('generate-config-docs', () => {
 
     test('should_mark_deprecated_options', () => {
       expect(CONFIG_OPTION_METADATA.technicalTerms.deprecated).toBe(true);
-      expect(CONFIG_OPTION_METADATA.properNouns.deprecated).toBe(true);
+      expect(CONFIG_OPTION_METADATA.specialTerms.deprecated).toBe(true);
+    });
+
+    test('should_treat_acronyms_and_proper_nouns_as_first_class', () => {
+      expect(CONFIG_OPTION_METADATA.acronyms.deprecated).toBeUndefined();
+      expect(CONFIG_OPTION_METADATA.properNouns.deprecated).toBeUndefined();
     });
 
     test('should_have_defaults_for_non_deprecated_options', () => {


### PR DESCRIPTION
## Summary

- **Part A (#233)**: `specialTerms` forced casing both ways — adding a proper noun to allow its capitalized form also flagged the legitimate lowercase homograph. Split into `acronyms` (must be uppercase) and `properNouns` (capitalized form allowed; lowercase common-word usage not flagged). `specialTerms` retained as a deprecated alias for `properNouns` (backward compatible).
- **Part B**: residual SC001 false positives — the all-caps check now exempts digit-bearing tokens (`25KB`, `BCE-500`), and hyphenated-segment special terms are matched whole in bold-text validation (`Anglo-Saxon`, `high-CEFR`).

Closes #233

## Test plan

### Automated testing
- [x] Full suite passes (1,620 passed, 0 failed, 35 snapshots)
- [x] New tests cover acronyms/properNouns semantics, the deprecated alias, and the Part B FP classes
- [x] `npm run lint` clean
- [x] `build (20)` / `build (22)` CI checks pass

### Known pre-existing failures (not introduced here) *(optional)*
- `security` (osv-scanner dependency advisories) and `lint` (PR-template MD041) fail on `main`.

## Breaking changes

None — `specialTerms` still works via a deprecated alias to `properNouns`.

## Documentation

- [x] `docs/configuration.md` and `recommended-config.jsonc` updated for the new keys