### PR TITLE
Align ADR-002 with Node >=20 engine requirement

### DIFF
--- a/docs/adr/adr-002-native-esm-distribution.md
+++ b/docs/adr/adr-002-native-esm-distribution.md
@@ -67,10 +67,10 @@ We will eliminate the Babel transpilation step and ship native ES modules direct
 
 **Negative:**
 
-- Potential compatibility issues with very old Node.js versions (pre-18)
-  - Mitigation: `package.json` already enforces `"engines": { "node": ">=18" }`
+- Potential compatibility issues with very old Node.js versions
+  - Mitigation: `package.json` enforces `"engines": { "node": ">=20" }`
 - Consumers on legacy systems may need to upgrade
-  - Mitigation: Node.js 18 is already LTS; 14 and 16 are EOL
+  - Mitigation: Node.js 20 is LTS; 18 and earlier are EOL
 
 **Testing:**
 


### PR DESCRIPTION
## Summary

- ADR-002 stated `package.json` enforces `"engines": { "node": ">=18" }` and called Node 18 current LTS, contradicting the `>=20` requirement enforced everywhere else (`.nvmrc`, `package.json`, `AGENTS.md`, `docs/testing.md`, ADR-004).
- Updated the two stale mitigation lines to reflect the actual `>=20` engine and current LTS/EOL status.

The threshold (ADR-001 `0.7`) and Node version contradictions in ADR-001, ADR-004, AGENTS.md, and `.nvmrc` were already resolved on `main`; this PR closes the remaining `>=18` references in ADR-002.

Closes #223

## Test plan

### Automated testing
- [x] `markdownlint-cli2` passes on the changed file (0 errors)

### Manual testing
- [x] Verified `package.json` engines is `>=20.20.2`, confirming the corrected reference
- [x] Grepped docs for remaining `>=18` references — none remain

## Breaking changes

None — documentation only.

## Documentation

- [x] ADR-002 updated to match the enforced Node engine