### PR TITLE
Add shared line-scanning context helper for rules

### DIFF
--- a/src/rules/backtick-code-elements.js
+++ b/src/rules/backtick-code-elements.js
@@ -19,12 +19,12 @@ import {
   logValidationErrors,
   createMarkdownlintLogger
 } from './config-validation.js';
-import { getCodeBlockLines, getInlineCodeSpans, isInCodeSpan } from './shared-utils.js';
+import { getInlineCodeSpans, isInCodeSpan } from './shared-utils.js';
+import { buildLineContext } from './shared-context.js';
 import { isDomainInProse } from './shared-heuristics.js';
 import {
   inMarkdownLink,
   inWikiLink,
-  inHtmlComment,
   inHtmlSemanticTag,
   inLatexMath,
   isLikelyFilePath
@@ -88,14 +88,15 @@ function backtickCodeElements(params, onError) {
   const allIgnoredTerms = new Set([...ignoredTerms, ...userIgnoredTerms]);
 
   const lines = params.lines;
-  // Use getCodeBlockLines for proper fence length tracking (handles 4-backtick fences etc.)
-  const codeBlockLines = getCodeBlockLines(lines);
+  // Shared context map tracks fenced/indented code (with proper fence-length
+  // handling), inline code, link destinations, and HTML comments.
+  const context = buildLineContext(lines);
   let inMathBlock = false;
 
   for (let i = 0; i < lines.length; i++) {
     const lineNumber = i + 1;
     const line = lines[i];
-    const inCodeBlock = codeBlockLines[i];
+    const inCodeBlock = context.isInFencedCode(i);
 
     // Skip code block fence lines
     if (inCodeBlock && /^(`{3,}|~{3,})/.test(line.trim())) {
@@ -266,7 +267,7 @@ function backtickCodeElements(params, onError) {
           continue;
         }
         // Skip if inside a Markdown link, wiki link, HTML comment, or angle bracket autolink
-        if (inMarkdownLink(line, start, end) || inWikiLink(line, start, end) || inHtmlComment(line, start, end) || inHtmlSemanticTag(line, start, end)) {
+        if (inMarkdownLink(line, start, end) || inWikiLink(line, start, end) || context.isInHtmlComment(i, start) || inHtmlSemanticTag(line, start, end)) {
           continue;
         }
 

--- a/src/rules/no-dead-internal-links.js
+++ b/src/rules/no-dead-internal-links.js
@@ -18,8 +18,9 @@ import {
   validateBoolean,
   validateConfig, 
   logValidationErrors,
-  createMarkdownlintLogger 
+  createMarkdownlintLogger
 } from './config-validation.js';
+import { buildLineContext } from './shared-context.js';
 
 // Performance optimization: Cache for file existence and heading extraction
 // These caches are shared across all rule invocations within a single lint run
@@ -96,23 +97,6 @@ function extractHeadings(content) {
   }
 
   return headings;
-}
-
-/**
- * Replace the contents of inline code spans with spaces so that links inside
- * backtick-delimited spans are not scanned. Column offsets are preserved by
- * substituting equal-length whitespace, keeping reported ranges accurate.
- *
- * Handles variable-length backtick runs per CommonMark: a span opened with N
- * backticks closes on the next run of exactly N backticks.
- * @param {string} line - A single line of markdown (already outside any fence)
- * @returns {string} The line with inline code span contents blanked out
- */
-function maskInlineCode(line) {
-  // Match a backtick run of length N, the shortest content, then a backtick
-  // run of exactly N (CommonMark inline code). Blank out the whole span.
-  const spanPattern = /(`+)([\s\S]*?)\1(?!`)/g;
-  return line.replace(spanPattern, (whole) => ' '.repeat(whole.length));
 }
 
 /**
@@ -338,51 +322,30 @@ function noDeadInternalLinks(params, onError) {
   // PERFORMANCE: Regex compilation is cached by V8, so this is not a bottleneck
   const linkPattern = /\[([^\]]+)\]\(([^)]+)\)/g;
 
-  // Track fenced code blocks so links inside them are not scanned.
-  // A fence opens on a line of three or more backticks or tildes and closes
-  // on the next line of the same fence character (length >= the opener).
-  let inFence = false;
-  let fenceChar = '';
-  let fenceLen = 0;
+  // Shared context map handles fenced code and inline code so links inside
+  // them are not scanned, keeping context detection consistent across rules.
+  const context = buildLineContext(lines);
 
   for (let i = 0; i < lines.length; i++) {
     const lineNumber = i + 1;
-    const rawLine = lines[i];
-
-    // Detect fence open/close markers (allow up to 3 leading spaces of indent).
-    const fenceMatch = rawLine.match(/^ {0,3}(`{3,}|~{3,})/);
-    if (fenceMatch) {
-      const marker = fenceMatch[1];
-      const markerChar = marker[0];
-      if (!inFence) {
-        inFence = true;
-        fenceChar = markerChar;
-        fenceLen = marker.length;
-        continue;
-      }
-      // Closing fence: same char and at least as long, with no info string.
-      if (markerChar === fenceChar && marker.length >= fenceLen && rawLine.trim() === marker) {
-        inFence = false;
-        fenceChar = '';
-        fenceLen = 0;
-        continue;
-      }
-    }
+    const line = lines[i];
 
     // Skip every line inside a fenced code block.
-    if (inFence) {
+    if (context.isInFencedCode(i)) {
       continue;
     }
 
-    // Mask inline code spans so links inside backticks are not scanned.
-    // Replacing span contents with spaces preserves column offsets for ranges.
-    const line = maskInlineCode(rawLine);
-
+    linkPattern.lastIndex = 0;
     let match;
     while ((match = linkPattern.exec(line)) !== null) {
       // const linkText = match[1]; // unused for now
       let linkUrl = match[2];
       const columnStart = match.index + 1;
+
+      // Skip links whose opening bracket sits inside an inline code span.
+      if (context.isInInlineCode(i, match.index)) {
+        continue;
+      }
 
       // Strip a single pair of angle brackets from the destination:
       // [text](<path with spaces.md>) -> "path with spaces.md".

--- a/src/rules/no-literal-ampersand.js
+++ b/src/rules/no-literal-ampersand.js
@@ -12,27 +12,37 @@ import {
   logValidationErrors,
   createMarkdownlintLogger 
 } from './config-validation.js';
-import { getCodeBlockLines, isInInlineCode } from './shared-utils.js';
 import { ampersandDefaultExceptions } from './shared-constants.js';
 import { createSafeFixInfo } from './autofix-safety.js';
+import { buildLineContext } from './shared-context.js';
 
 /**
  * Check if a character position is inside inline code or other special context.
+ *
+ * Code, link, comment, and frontmatter contexts are delegated to the shared
+ * line-context helper so detection stays consistent across rules. Only the
+ * ampersand-specific HTML entity and inline link-text checks live here.
+ *
  * @param {string} line - The line content
  * @param {number} position - Character position to check
  * @param {boolean} skipInlineCode - Whether to skip inline code contexts
+ * @param {import('./shared-context.js').LineContext} context - Shared context map
+ * @param {number} lineIndex - Zero-based index of the line
  * @returns {boolean} True if position should be ignored
  */
-function isInSpecialContext(line, position, skipInlineCode = true) {
-  // Check if inside inline code (backticks) based on configuration
-  if (skipInlineCode && isInInlineCode(line, position)) {
+function isInSpecialContext(line, position, skipInlineCode, context, lineIndex) {
+  // Code spans, link destinations, and HTML comments come from the shared map.
+  if (skipInlineCode && context.isInInlineCode(lineIndex, position)) {
+    return true;
+  }
+  if (context.isInLinkDestination(lineIndex, position) ||
+      context.isInHtmlComment(lineIndex, position)) {
     return true;
   }
 
-  // Check if inside HTML tag or entity
   const beforePosition = line.substring(0, position);
   const afterPosition = line.substring(position + 1); // +1 to skip the & itself
-  
+
   // Check for HTML entities like &amp; &lt; &gt; etc.
   // Look for pattern like &word; where we are at the &
   if (/^[a-zA-Z0-9#]+;/.test(afterPosition)) {
@@ -51,19 +61,11 @@ function isInSpecialContext(line, position, skipInlineCode = true) {
     }
   }
 
-  // Check if inside markdown link or image syntax
+  // Inside link text [text & more]: the shared map only covers destinations,
+  // so guard the bracketed label here.
   const lastOpenBracket = beforePosition.lastIndexOf('[');
   const lastCloseBracket = beforePosition.lastIndexOf(']');
-  const lastOpenParen = beforePosition.lastIndexOf('(');
-  const lastCloseParen = beforePosition.lastIndexOf(')');
-  
-  // Inside link text [text & more]
   if (lastOpenBracket > lastCloseBracket) {
-    return true;
-  }
-  
-  // Inside link URL (text)[url & params]
-  if (lastOpenParen > lastCloseParen && lastCloseBracket > lastOpenBracket) {
     return true;
   }
 
@@ -113,11 +115,13 @@ const BRAND_NAMES_WITH_AMPERSAND = [
  * @param {number} position - Position of the ampersand
  * @param {boolean} skipInlineCode - Whether to skip inline code contexts
  * @param {string[]} exceptions - Array of exception patterns
+ * @param {import('./shared-context.js').LineContext} context - Shared context map
+ * @param {number} lineIndex - Zero-based index of the line
  * @returns {boolean} True if this ampersand should be flagged
  */
-function shouldFlagAmpersand(line, position, skipInlineCode = true, exceptions = []) {
+function shouldFlagAmpersand(line, position, skipInlineCode, exceptions, context, lineIndex) {
   // Skip if in special context
-  if (isInSpecialContext(line, position, skipInlineCode)) {
+  if (isInSpecialContext(line, position, skipInlineCode, context, lineIndex)) {
     return false;
   }
 
@@ -190,7 +194,7 @@ function noLiteralAmpersand(params, onError) {
   const skipInlineCode = typeof config.skipInlineCode === 'boolean' ? config.skipInlineCode : true;
 
   const lines = params.lines;
-  const codeBlockLines = getCodeBlockLines(lines);
+  const context = buildLineContext(lines);
 
   for (let i = 0; i < lines.length; i++) {
     const lineNumber = i + 1;
@@ -201,15 +205,15 @@ function noLiteralAmpersand(params, onError) {
       continue;
     }
 
-    // Skip lines in code blocks based on configuration
-    if (skipCodeBlocks && codeBlockLines[i]) {
+    // Skip lines in fenced code or YAML frontmatter based on configuration.
+    if (skipCodeBlocks && (context.isInFencedCode(i) || context.isInFrontmatter(i))) {
       continue;
     }
 
     // Find all ampersands in the line
     for (let pos = 0; pos < line.length; pos++) {
       if (line[pos] === '&') {
-        if (shouldFlagAmpersand(line, pos, skipInlineCode, exceptions)) {
+        if (shouldFlagAmpersand(line, pos, skipInlineCode, exceptions, context, i)) {
           // Always provide fix for ampersand replacement since it's a safe operation
           const basicFixInfo = {
             editColumn: pos + 1,

--- a/src/rules/sentence-case-heading.js
+++ b/src/rules/sentence-case-heading.js
@@ -37,7 +37,8 @@ import {
   logValidationErrors,
   createMarkdownlintLogger
 } from './config-validation.js';
-import { stripLeadingDecorations, truncateAtEmoji, getCodeBlockLines } from './shared-utils.js';
+import { stripLeadingDecorations, truncateAtEmoji } from './shared-utils.js';
+import { buildLineContext } from './shared-context.js';
 import { extractHeadingText } from './sentence-case/token-extraction.js';
 import { validateHeading } from './sentence-case/case-classifier.js';
 import { validateBoldText } from './sentence-case/bold-text-classifier.js';
@@ -296,14 +297,14 @@ function basicSentenceCaseHeadingFunction(params, onError) {
   // Bold text in the middle or end of list items should NOT be validated.
   // This fixes ~2,700 false positives (issue #105).
 
-  // Get code block lines to skip content inside fenced code blocks
-  const codeBlockLines = getCodeBlockLines(lines);
+  // Shared context map skips content inside fenced code and frontmatter.
+  const context = buildLineContext(lines);
 
   lines.forEach((line, index) => {
     const lineNumber = index + 1;
 
     // Skip lines inside code blocks - never flag or autofix code block content
-    if (codeBlockLines[index]) {
+    if (context.isInFencedCode(index) || context.isInFrontmatter(index)) {
       return;
     }
 

--- a/src/rules/shared-context.js
+++ b/src/rules/shared-context.js
@@ -1,0 +1,293 @@
+// @ts-check
+
+/**
+ * Shared line-scanning context helper.
+ *
+ * Line-scanning rules (DL001, BCE001, SC001, no-literal-ampersand, ...) all need
+ * to answer the same question before flagging a match: is this offset inside a
+ * context where Markdown source should not be treated as prose? Historically each
+ * rule reimplemented its own fence/inline-code/link/comment/frontmatter detection
+ * with slightly different regex, so false-positive fixes drifted per rule.
+ *
+ * This module centralizes that detection. {@link buildLineContext} scans a
+ * document once and returns predicates keyed by (lineIndex, column) for each
+ * context type, plus a unified {@link LineContext#isInCode} predicate.
+ *
+ * All line indices are zero-based; columns are zero-based character offsets.
+ */
+
+import { getInlineCodeSpans } from './shared-utils.js';
+
+/**
+ * @typedef {Object} LineContext
+ * @property {(lineIndex: number, column: number) => boolean} isInFencedCode
+ *   True when the line is inside a fenced code block (including its marker
+ *   lines) or an indented code block.
+ * @property {(lineIndex: number, column: number) => boolean} isInInlineCode
+ *   True when the offset is inside an inline code span. Always false inside a
+ *   fenced block (inline spans are not parsed there).
+ * @property {(lineIndex: number, column: number) => boolean} isInLinkDestination
+ *   True when the offset is inside the destination of a `[text](dest)` link.
+ * @property {(lineIndex: number, column: number) => boolean} isInHtmlComment
+ *   True when the offset is inside an HTML comment, including multi-line comments.
+ * @property {(lineIndex: number, column: number) => boolean} isInFrontmatter
+ *   True when the offset is inside a leading YAML frontmatter block.
+ * @property {(lineIndex: number, column: number) => boolean} isInCode
+ *   Unified predicate: true when the offset is in any non-prose context above.
+ * @property {(lineIndex: number, column: number) => boolean} isInProse
+ *   Convenience inverse of {@link LineContext#isInCode}.
+ */
+
+const FENCE_OPEN_RE = /^ {0,3}(`{3,}|~{3,})/;
+const INDENT_CODE_RE = /^(?: {4}|\t)/;
+
+/**
+ * Detect a leading YAML frontmatter block.
+ *
+ * Frontmatter is only recognized when the very first line is exactly `---`
+ * (a `---` later in the document is a thematic break, not frontmatter). The
+ * block ends on the next line that is exactly `---` or `...`.
+ *
+ * @param {string[]} lines - Document lines.
+ * @returns {boolean[]} Per-line flag; frontmatter delimiter lines are excluded
+ *   so that only the body of the block is treated as non-prose.
+ */
+function computeFrontmatterLines(lines) {
+  const flags = new Array(lines.length).fill(false);
+  if (lines.length === 0 || lines[0].trim() !== '---') {
+    return flags;
+  }
+  for (let i = 1; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed === '---' || trimmed === '...') {
+      return flags; // closing delimiter ends the block
+    }
+    flags[i] = true;
+  }
+  return flags;
+}
+
+/**
+ * Detect fenced and indented code regions.
+ *
+ * Fences respect their character and length so a shorter inner fence does not
+ * prematurely close an outer one. Indented code blocks (four leading spaces or
+ * a tab, with content) are also treated as code when outside a fence.
+ *
+ * @param {string[]} lines - Document lines.
+ * @param {boolean[]} frontmatterLines - Lines already claimed by frontmatter,
+ *   which must not be scanned for fences.
+ * @returns {boolean[]} Per-line flag including the fence marker lines themselves.
+ */
+function computeFencedLines(lines, frontmatterLines) {
+  const flags = new Array(lines.length).fill(false);
+  let fenceChar = '';
+  let fenceLen = 0;
+  let inFence = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (frontmatterLines[i]) {
+      continue;
+    }
+    const line = lines[i];
+    const match = FENCE_OPEN_RE.exec(line);
+
+    if (match) {
+      const marker = match[1];
+      const markerChar = marker[0];
+      const markerLen = marker.length;
+
+      if (!inFence) {
+        inFence = true;
+        fenceChar = markerChar;
+        fenceLen = markerLen;
+        flags[i] = true;
+        continue;
+      }
+
+      // A closing fence matches the opener's char, is at least as long, and
+      // carries no info string. Anything else is content inside the fence.
+      if (markerChar === fenceChar && markerLen >= fenceLen && line.trim() === marker) {
+        inFence = false;
+        fenceChar = '';
+        fenceLen = 0;
+        flags[i] = true;
+        continue;
+      }
+    }
+
+    if (inFence) {
+      flags[i] = true;
+      continue;
+    }
+
+    // Indented code block: four-space or tab indent with non-blank content.
+    if (line.length > 4 && INDENT_CODE_RE.test(line) && line.trim() !== '') {
+      flags[i] = true;
+    }
+  }
+
+  return flags;
+}
+
+/**
+ * Detect HTML comment regions, including comments spanning multiple lines.
+ *
+ * @param {string[]} lines - Document lines.
+ * @param {boolean[]} fencedLines - Lines inside fenced code, where `<!--` is
+ *   literal text and must be ignored.
+ * @returns {Array<Array<[number, number]>>} Per-line list of `[start, end)`
+ *   column ranges covered by a comment. A line fully inside a multi-line
+ *   comment yields a single range spanning its whole length.
+ */
+function computeHtmlCommentRanges(lines, fencedLines) {
+  const ranges = lines.map(() => /** @type {Array<[number, number]>} */ ([]));
+  let inComment = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (fencedLines[i]) {
+      continue;
+    }
+    const line = lines[i];
+    let pos = 0;
+
+    while (pos < line.length) {
+      if (!inComment) {
+        const open = line.indexOf('<!--', pos);
+        if (open === -1) {
+          break;
+        }
+        const close = line.indexOf('-->', open + 4);
+        if (close === -1) {
+          ranges[i].push([open, line.length]);
+          inComment = true;
+          break;
+        }
+        ranges[i].push([open, close + 3]);
+        pos = close + 3;
+      } else {
+        const close = line.indexOf('-->', pos);
+        if (close === -1) {
+          ranges[i].push([0, line.length]);
+          break;
+        }
+        ranges[i].push([0, close + 3]);
+        inComment = false;
+        pos = close + 3;
+      }
+    }
+  }
+
+  return ranges;
+}
+
+/**
+ * Detect link destination ranges of the form `[text](destination)`.
+ *
+ * Only the destination span (the content between the parentheses, excluding any
+ * angle brackets) is reported. Link text and surrounding prose are not.
+ *
+ * @param {string[]} lines - Document lines.
+ * @param {boolean[]} fencedLines - Lines inside fenced code, which are skipped.
+ * @returns {Array<Array<[number, number]>>} Per-line `[start, end)` ranges.
+ */
+function computeLinkDestinationRanges(lines, fencedLines) {
+  const ranges = lines.map(() => /** @type {Array<[number, number]>} */ ([]));
+  const linkPattern = /\[[^\]]*\]\(([^)]*)\)/g;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (fencedLines[i]) {
+      continue;
+    }
+    const line = lines[i];
+    linkPattern.lastIndex = 0;
+    let match;
+    while ((match = linkPattern.exec(line)) !== null) {
+      const dest = match[1];
+      const open = match.index + match[0].indexOf('(', match[0].indexOf(']')) + 1;
+      let start = open;
+      let end = open + dest.length;
+      // Exclude a single pair of angle brackets: [t](<a b.md>).
+      if (dest.startsWith('<') && dest.endsWith('>')) {
+        start += 1;
+        end -= 1;
+      }
+      ranges[i].push([start, end]);
+    }
+  }
+
+  return ranges;
+}
+
+/**
+ * @param {Array<[number, number]>} spans - `[start, end)` ranges.
+ * @param {number} column - Column offset to test.
+ * @returns {boolean} True when the column falls within any span.
+ */
+function columnInRanges(spans, column) {
+  return spans.some(([start, end]) => column >= start && column < end);
+}
+
+/**
+ * Scan a document once and return context predicates for its offsets.
+ *
+ * @param {string[]} lines - Document lines (e.g. markdownlint's `params.lines`).
+ * @returns {LineContext} Context predicates for the document.
+ */
+export function buildLineContext(lines) {
+  const safeLines = Array.isArray(lines) ? lines : [];
+
+  const frontmatterLines = computeFrontmatterLines(safeLines);
+  const fencedLines = computeFencedLines(safeLines, frontmatterLines);
+  const commentRanges = computeHtmlCommentRanges(safeLines, fencedLines);
+  const linkRanges = computeLinkDestinationRanges(safeLines, fencedLines);
+
+  // Inline code spans only matter on lines that are neither fenced nor
+  // frontmatter; computing them lazily per line keeps the common case cheap.
+  /** @type {Array<Array<[number, number]>> | null} */
+  const inlineSpanCache = new Array(safeLines.length).fill(null);
+  const inlineComputed = new Array(safeLines.length).fill(false);
+
+  function inlineSpansFor(lineIndex) {
+    if (!inlineComputed[lineIndex]) {
+      inlineSpanCache[lineIndex] =
+        fencedLines[lineIndex] || frontmatterLines[lineIndex]
+          ? []
+          : getInlineCodeSpans(safeLines[lineIndex]);
+      inlineComputed[lineIndex] = true;
+    }
+    return inlineSpanCache[lineIndex] || [];
+  }
+
+  const inBounds = (lineIndex) => lineIndex >= 0 && lineIndex < safeLines.length;
+
+  const isInFencedCode = (lineIndex) => inBounds(lineIndex) && fencedLines[lineIndex];
+
+  const isInFrontmatter = (lineIndex) => inBounds(lineIndex) && frontmatterLines[lineIndex];
+
+  const isInInlineCode = (lineIndex, column) =>
+    inBounds(lineIndex) && columnInRanges(inlineSpansFor(lineIndex), column);
+
+  const isInLinkDestination = (lineIndex, column) =>
+    inBounds(lineIndex) && columnInRanges(linkRanges[lineIndex], column);
+
+  const isInHtmlComment = (lineIndex, column) =>
+    inBounds(lineIndex) && columnInRanges(commentRanges[lineIndex], column);
+
+  const isInCode = (lineIndex, column) =>
+    isInFencedCode(lineIndex) ||
+    isInFrontmatter(lineIndex) ||
+    isInInlineCode(lineIndex, column) ||
+    isInLinkDestination(lineIndex, column) ||
+    isInHtmlComment(lineIndex, column);
+
+  return {
+    isInFencedCode,
+    isInInlineCode,
+    isInLinkDestination,
+    isInHtmlComment,
+    isInFrontmatter,
+    isInCode,
+    isInProse: (lineIndex, column) => !isInCode(lineIndex, column)
+  };
+}

--- a/tests/features/shared-context-integration.test.js
+++ b/tests/features/shared-context-integration.test.js
@@ -1,0 +1,120 @@
+// @ts-check
+
+/**
+ * Integration tests for the shared line-scanning context helper.
+ *
+ * These exercise the issue #232 acceptance scenarios end-to-end: line-scanning
+ * rules must not flag matches that sit inside fenced code, inline code spans,
+ * link destinations, or YAML frontmatter, while still flagging real prose.
+ */
+
+import { describe, test, expect } from '@jest/globals';
+import { lint } from 'markdownlint/promise';
+import backtickCodeElements from '../../src/rules/backtick-code-elements.js';
+import noDeadInternalLinks from '../../src/rules/no-dead-internal-links.js';
+import noLiteralAmpersand from '../../src/rules/no-literal-ampersand.js';
+
+const baseConfig = {
+  default: false,
+};
+
+describe('shared-context integration across line-scanning rules', () => {
+  test('should_not_flag_example_links_inside_markdown_fence_for_DL001', async () => {
+    const input = [
+      '# Doc',
+      '',
+      '```markdown',
+      '[broken](./does-not-exist.md)',
+      '```',
+      '',
+      'Real prose.',
+    ].join('\n');
+
+    const result = await lint({
+      strings: { 'doc.md': input },
+      config: { ...baseConfig, 'no-dead-internal-links': true },
+      customRules: [noDeadInternalLinks],
+    });
+
+    expect(result['doc.md']).toHaveLength(0);
+  });
+
+  test('should_not_flag_link_inside_inline_code_for_DL001', async () => {
+    const input = 'Use `[x](./missing.md)` as a template.';
+
+    const result = await lint({
+      strings: { 'doc.md': input },
+      config: { ...baseConfig, 'no-dead-internal-links': true },
+      customRules: [noDeadInternalLinks],
+    });
+
+    expect(result['doc.md']).toHaveLength(0);
+  });
+
+  test('should_not_flag_url_inside_inline_code_as_path_for_BCE001', async () => {
+    const input = 'Visit `https://example.com/path` for details.';
+
+    const result = await lint({
+      strings: { input },
+      config: { ...baseConfig, 'backtick-code-elements': true },
+      customRules: [backtickCodeElements],
+    });
+
+    expect(result.input).toHaveLength(0);
+  });
+
+  test('should_not_flag_terms_inside_fenced_code_for_BCE001', async () => {
+    const input = ['Prose.', '', '```', '/etc/hosts', '```'].join('\n');
+
+    const result = await lint({
+      strings: { input },
+      config: { ...baseConfig, 'backtick-code-elements': true },
+      customRules: [backtickCodeElements],
+    });
+
+    expect(result.input).toHaveLength(0);
+  });
+
+  test('should_not_flag_ampersand_inside_frontmatter', async () => {
+    const input = [
+      '---',
+      'title: Cats & Dogs',
+      '---',
+      '',
+      'Body text.',
+    ].join('\n');
+
+    const result = await lint({
+      strings: { input },
+      config: { ...baseConfig, 'no-literal-ampersand': true },
+      customRules: [noLiteralAmpersand],
+    });
+
+    expect(result.input).toHaveLength(0);
+  });
+
+  test('should_still_flag_ampersand_in_body_prose', async () => {
+    const input = ['---', 'title: T', '---', '', 'Cats & dogs.'].join('\n');
+
+    const result = await lint({
+      strings: { input },
+      config: { ...baseConfig, 'no-literal-ampersand': true },
+      customRules: [noLiteralAmpersand],
+    });
+
+    expect(result.input).toHaveLength(1);
+    expect(result.input[0].ruleNames).toContain('no-literal-ampersand');
+  });
+
+  test('should_not_flag_ampersand_inside_link_destination', async () => {
+    const input = 'See [the page](https://example.com/?a=1&b=2) now.';
+
+    const result = await lint({
+      strings: { input },
+      config: { ...baseConfig, 'no-literal-ampersand': true },
+      customRules: [noLiteralAmpersand],
+    });
+
+    expect(result.input).toHaveLength(0);
+  });
+});

--- a/tests/unit/shared-context.test.js
+++ b/tests/unit/shared-context.test.js
@@ -1,0 +1,193 @@
+// @ts-check
+
+/**
+ * Unit tests for the shared line-scanning context helper.
+ *
+ * The helper answers, for a given line + column, whether that offset sits inside
+ * fenced code, an inline code span, a link destination, an HTML comment, or YAML
+ * frontmatter. Line-scanning rules route through it instead of reimplementing
+ * their own context regex.
+ */
+
+import { buildLineContext } from '../../src/rules/shared-context.js';
+
+describe('shared-context', () => {
+  describe('fenced code blocks', () => {
+    test('should_report_fenced_code_when_inside_backtick_fence', () => {
+      const lines = ['Intro', '```js', 'const x = 1;', '```', 'Outro'];
+      const ctx = buildLineContext(lines);
+
+      expect(ctx.isInFencedCode(2, 0)).toBe(true); // const x line
+      expect(ctx.isInFencedCode(0, 0)).toBe(false); // Intro
+      expect(ctx.isInFencedCode(4, 0)).toBe(false); // Outro
+    });
+
+    test('should_treat_fence_marker_lines_as_fenced_code', () => {
+      const lines = ['```', 'code', '```'];
+      const ctx = buildLineContext(lines);
+
+      expect(ctx.isInFencedCode(0, 0)).toBe(true);
+      expect(ctx.isInFencedCode(1, 0)).toBe(true);
+      expect(ctx.isInFencedCode(2, 0)).toBe(true);
+    });
+
+    test('should_handle_tilde_fences', () => {
+      const lines = ['~~~', 'code', '~~~', 'after'];
+      const ctx = buildLineContext(lines);
+
+      expect(ctx.isInFencedCode(1, 0)).toBe(true);
+      expect(ctx.isInFencedCode(3, 0)).toBe(false);
+    });
+
+    test('should_treat_indented_code_blocks_as_code', () => {
+      const lines = ['Para', '', '    indented code & more', '', 'After'];
+      const ctx = buildLineContext(lines);
+
+      expect(ctx.isInFencedCode(2, 0)).toBe(true);
+      expect(ctx.isInFencedCode(0, 0)).toBe(false);
+      expect(ctx.isInFencedCode(4, 0)).toBe(false);
+    });
+
+    test('should_not_close_fence_on_shorter_inner_fence', () => {
+      const lines = ['````', '```', 'still code', '````', 'after'];
+      const ctx = buildLineContext(lines);
+
+      expect(ctx.isInFencedCode(1, 0)).toBe(true); // inner ``` is content
+      expect(ctx.isInFencedCode(2, 0)).toBe(true);
+      expect(ctx.isInFencedCode(4, 0)).toBe(false); // after the 4-backtick close
+    });
+  });
+
+  describe('inline code spans', () => {
+    test('should_report_inline_code_when_offset_inside_span', () => {
+      const line = 'Use `npm install` to set up.';
+      const lines = [line];
+      const ctx = buildLineContext(lines);
+
+      const inside = line.indexOf('npm');
+      const outside = line.indexOf('Use');
+      expect(ctx.isInInlineCode(0, inside)).toBe(true);
+      expect(ctx.isInInlineCode(0, outside)).toBe(false);
+    });
+
+    test('should_handle_multi_backtick_inline_spans', () => {
+      const line = 'Literal `` ` `` backtick here.';
+      const lines = [line];
+      const ctx = buildLineContext(lines);
+
+      const insideSpan = line.indexOf('`', line.indexOf('`` ') + 3);
+      expect(ctx.isInInlineCode(0, insideSpan)).toBe(true);
+      const after = line.indexOf('backtick');
+      expect(ctx.isInInlineCode(0, after)).toBe(false);
+    });
+
+    test('should_not_report_inline_code_inside_a_fence', () => {
+      const lines = ['```', '`not a span`', '```'];
+      const ctx = buildLineContext(lines);
+      // Inside a fence, every offset is "code context"; inline detection
+      // should not run, but the unified predicate must still report code.
+      expect(ctx.isInCode(1, 0)).toBe(true);
+    });
+  });
+
+  describe('link destinations', () => {
+    test('should_report_link_destination_offsets', () => {
+      const line = 'See [docs](https://example.com/path) now.';
+      const lines = [line];
+      const ctx = buildLineContext(lines);
+
+      const destPos = line.indexOf('https://example.com');
+      expect(ctx.isInLinkDestination(0, destPos)).toBe(true);
+
+      const textPos = line.indexOf('docs');
+      expect(ctx.isInLinkDestination(0, textPos)).toBe(false);
+
+      const prosePos = line.indexOf('now');
+      expect(ctx.isInLinkDestination(0, prosePos)).toBe(false);
+    });
+
+    test('should_handle_angle_bracketed_destinations', () => {
+      const line = 'Link [x](<a b.md>) end.';
+      const lines = [line];
+      const ctx = buildLineContext(lines);
+
+      const destPos = line.indexOf('a b.md');
+      expect(ctx.isInLinkDestination(0, destPos)).toBe(true);
+    });
+  });
+
+  describe('HTML comments', () => {
+    test('should_report_single_line_html_comment', () => {
+      const line = 'Text <!-- TODO & stuff --> after';
+      const lines = [line];
+      const ctx = buildLineContext(lines);
+
+      const insidePos = line.indexOf('TODO');
+      expect(ctx.isInHtmlComment(0, insidePos)).toBe(true);
+
+      const beforePos = line.indexOf('Text');
+      const afterPos = line.indexOf('after');
+      expect(ctx.isInHtmlComment(0, beforePos)).toBe(false);
+      expect(ctx.isInHtmlComment(0, afterPos)).toBe(false);
+    });
+
+    test('should_report_multi_line_html_comment', () => {
+      const lines = ['Before', '<!-- start', 'middle & body', 'end -->', 'After'];
+      const ctx = buildLineContext(lines);
+
+      expect(ctx.isInHtmlComment(2, 0)).toBe(true); // middle line
+      expect(ctx.isInHtmlComment(0, 0)).toBe(false);
+      expect(ctx.isInHtmlComment(4, 0)).toBe(false);
+    });
+  });
+
+  describe('YAML frontmatter', () => {
+    test('should_report_frontmatter_lines', () => {
+      const lines = ['---', 'title: A & B', 'tags: [x]', '---', '# Heading'];
+      const ctx = buildLineContext(lines);
+
+      expect(ctx.isInFrontmatter(1, 0)).toBe(true);
+      expect(ctx.isInFrontmatter(2, 0)).toBe(true);
+      expect(ctx.isInFrontmatter(4, 0)).toBe(false); // heading is body
+    });
+
+    test('should_not_treat_horizontal_rule_as_frontmatter', () => {
+      const lines = ['# Heading', '', '---', 'body'];
+      const ctx = buildLineContext(lines);
+
+      expect(ctx.isInFrontmatter(2, 0)).toBe(false);
+    });
+  });
+
+  describe('unified isInCode / isInProse predicate', () => {
+    test('should_flag_code_for_fenced_inline_and_link_destinations', () => {
+      const lines = [
+        '---',
+        'k: v',
+        '---',
+        'Prose [t](http://x.com) and `code` and <!-- c -->.',
+        '```',
+        'fenced',
+        '```'
+      ];
+      const ctx = buildLineContext(lines);
+
+      // frontmatter body
+      expect(ctx.isInCode(1, 0)).toBe(true);
+      // link destination
+      const destPos = lines[3].indexOf('http://x.com');
+      expect(ctx.isInCode(3, destPos)).toBe(true);
+      // inline code
+      const codePos = lines[3].indexOf('code');
+      expect(ctx.isInCode(3, codePos)).toBe(true);
+      // html comment
+      const commentPos = lines[3].indexOf('<!--') + 5;
+      expect(ctx.isInCode(3, commentPos)).toBe(true);
+      // fenced
+      expect(ctx.isInCode(5, 0)).toBe(true);
+      // plain prose
+      const prosePos = lines[3].indexOf('Prose');
+      expect(ctx.isInCode(3, prosePos)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/rules/shared-context.js`: a single `buildLineContext` map answering whether a given line+column sits inside fenced/indented code, an inline code span, a link destination, an HTML comment (including multi-line), or YAML frontmatter.
- Route the four line-scanning rules through it, removing their duplicated context regex:
  - **DL001** drops its bespoke fence loop and `maskInlineCode`.
  - **no-literal-ampersand** delegates inline-code, link-destination, comment, and frontmatter checks (keeps its ampersand-specific HTML entity/tag and link-label handling).
  - **BCE001** uses the shared fenced-code and HTML-comment detection.
  - **SC001** bold-list scan skips fenced code and frontmatter via the map.
- `no-bare-url` (BU001) is token-based (markdown-it), not line-scanning, so it already respects code/link context inherently and needs no wiring.

Closes #232

## Test plan

### Automated testing
- [x] Unit tests pass (`tests/unit/shared-context.test.js` — 15 cases across all context types and boundaries)
- [x] Integration tests pass (`tests/features/shared-context-integration.test.js` — cross-rule code-embedded scenarios)
- [x] Full test suite passes (1 pre-existing unrelated `docs-consistency` failure about Node `>=18` doc references, present on `main` before this branch)

### Manual testing
- [x] Tested with representative data (fenced/inline/frontmatter/link fixtures)
- [x] Edge cases verified (nested fences, multi-backtick spans, multi-line comments, angle-bracketed destinations)

### Test coverage
- [x] New functionality has tests
- [x] Tests follow behavioral naming

## Breaking changes

None — backward compatible; rule outputs unchanged on existing fixtures.

## Documentation

- [x] Docstrings added for new public functions (`buildLineContext`, `LineContext` typedef)
- [ ] API documentation updated if public APIs added or changed *(optional)*
- [ ] README updated if public-facing behavior changed *(optional)*
