### PR TITLE
Guard BCE001 autofix against content corruption

### DIFF
--- a/src/rules/autofix-safety.js
+++ b/src/rules/autofix-safety.js
@@ -94,6 +94,53 @@ export function mergeAutofixSafetyConfig(overrides) {
 }
 
 /**
+ * Detect whether a backtick autofix would corrupt content (issue #234).
+ *
+ * Two corruption modes are rejected outright, independent of which BCE001
+ * pattern produced the match:
+ * 1. URL wrapping — wrapping a bare URL (scheme-prefixed like `https://...`
+ *    or `www.`-prefixed) in a code span turns a clickable link into dead code.
+ * 2. Intra-token insertion — a match that begins partway through a word (because
+ *    a regex could not cross an apostrophe or letter boundary) would insert a
+ *    backtick inside the word, e.g. "don'`t/wait`".
+ *
+ * @param {string} original - The matched token the fix would wrap.
+ * @param {Object} context - Fix context; `context.line` is the source line.
+ * @returns {{ corrupting: boolean, reason?: string }} Whether the fix corrupts.
+ */
+export function detectBacktickCorruption(original, context = {}) {
+  const token = typeof original === 'string' ? original : String(original || '');
+  if (!token) {
+    return { corrupting: false };
+  }
+
+  // URL wrapping: scheme-prefixed or bare www. URLs must never be code spans.
+  if (/^(?:https?|ftp|ftps|file):\/\//i.test(token) || /^www\.[\w-]+\.[\w-]/i.test(token)) {
+    return { corrupting: true, reason: 'Fix would wrap a bare URL in a code span' };
+  }
+
+  // Intra-token insertion: the match starts mid-word inside the source line.
+  // A real code element never begins immediately after a letter+apostrophe or a
+  // bare letter; that signals the regex split an ordinary prose word.
+  const line = typeof context.line === 'string' ? context.line : '';
+  if (line) {
+    const idx = line.indexOf(token);
+    if (idx > 0) {
+      const prev = line[idx - 1];
+      const prevPrev = idx >= 2 ? line[idx - 2] : '';
+      const startsAlnum = /[A-Za-z0-9]/.test(token[0]);
+      const afterApostrophe = (prev === "'" || prev === '’') && /\w/.test(prevPrev);
+      const afterLetter = /[A-Za-z0-9]/.test(prev);
+      if (startsAlnum && (afterApostrophe || afterLetter)) {
+        return { corrupting: true, reason: 'Fix would insert a backtick inside a token' };
+      }
+    }
+  }
+
+  return { corrupting: false };
+}
+
+/**
  * Detect ambiguous terms in text and return ambiguity information.
  * @param {string} text - Text to analyze
  * @returns {{ isAmbiguous: boolean, term?: string, info?: Object, type?: string }} Ambiguity info
@@ -358,6 +405,27 @@ export function createSafeFixInfo(originalFixInfo, ruleType, original, fixed, co
 
   // Use the existing safety check system for all rules
   const safetyCheck = shouldApplyAutofix(ruleType, original, fixed, context, config);
+
+  // For backtick rules, reject content-corrupting fixes before anything else
+  // (issue #234): URL wrapping and intra-token backtick insertion are never safe.
+  if (ruleType === 'backtick') {
+    const corruption = detectBacktickCorruption(original, context);
+    if (corruption.corrupting) {
+      const telemetry = getTelemetry();
+      telemetry.recordDecision({
+        rule: ruleType,
+        original,
+        fixed,
+        confidence: 0,
+        applied: false,
+        reason: corruption.reason,
+        heuristics: safetyCheck.heuristics,
+        file: context.file,
+        line: context.line
+      });
+      return null;
+    }
+  }
 
   // For backtick rules, also run the advanced analysis for additional insights
   let advancedAnalysis = null;

--- a/tests/features/autofix-corruption-guard.test.js
+++ b/tests/features/autofix-corruption-guard.test.js
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Regression tests for issue #234 — autofix corruption guard.
+ * BCE001 autofix must never insert a backtick inside a token, and must never
+ * wrap a bare URL (scheme-prefixed or www.-prefixed) in a code span.
+ */
+
+import { describe, test, expect } from '@jest/globals';
+import { lint } from 'markdownlint/promise';
+import { applyFixes } from 'markdownlint';
+import backtickRule from '../../src/rules/backtick-code-elements.js';
+import { createSafeFixInfo } from '../../src/rules/autofix-safety.js';
+
+/**
+ * Lint a string with BCE001 in fix mode and return the autofixed text.
+ * @param {string} content - Markdown to lint and fix.
+ * @returns {Promise<string>} The content after applying BCE001 fixes.
+ */
+async function autofix(content) {
+  const result = await lint({
+    strings: { t: content },
+    customRules: [backtickRule],
+    config: { default: false, 'backtick-code-elements': true },
+    resultVersion: 3,
+    fix: true
+  });
+  const fixes = (result.t || []).filter((v) => v.ruleNames.includes('BCE001'));
+  return applyFixes(content, fixes);
+}
+
+describe('issue #234 — autofix corruption guard', () => {
+  test('GIVEN slash-and-apostrophe prose WHEN BCE001 autofix runs THEN no backtick is inserted inside any token', async () => {
+    const input = "The sequence stop/don't/wait/wrong/undo/actually is prose.";
+    const output = await autofix(input);
+    expect(output).toBe(input);
+    expect(output).not.toContain("'`");
+    expect(output).not.toContain('`t/');
+  });
+
+  test('GIVEN a scheme-prefixed bare URL WHEN autofix runs THEN it is not wrapped in backticks', async () => {
+    const input = 'Refer to https://example.com/path/to/page for details.';
+    const output = await autofix(input);
+    expect(output).toBe(input);
+    expect(output).not.toContain('`http');
+  });
+
+  test('GIVEN a www-prefixed bare URL WHEN autofix runs THEN it is not wrapped in backticks', async () => {
+    const input = 'See www.example.com/a/b for details.';
+    const output = await autofix(input);
+    expect(output).toBe(input);
+    expect(output).not.toContain('`www');
+  });
+
+  describe('safety guard rejects intra-token and URL rewrites', () => {
+    test('GIVEN a scheme-prefixed URL WHEN createSafeFixInfo runs THEN the fix is rejected', () => {
+      const original = 'https://example.com/a/b';
+      const result = createSafeFixInfo(
+        { editColumn: 1, deleteCount: original.length, insertText: `\`${original}\`` },
+        'backtick',
+        original,
+        `\`${original}\``,
+        { type: 'code-element', line: `See ${original} now` }
+      );
+      expect(result).toBeNull();
+    });
+
+    test('GIVEN a www-prefixed bare URL WHEN createSafeFixInfo runs THEN the fix is rejected', () => {
+      const original = 'www.example.com/a/b';
+      const result = createSafeFixInfo(
+        { editColumn: 1, deleteCount: original.length, insertText: `\`${original}\`` },
+        'backtick',
+        original,
+        `\`${original}\``,
+        { type: 'code-element', line: `See ${original} now` }
+      );
+      expect(result).toBeNull();
+    });
+
+    test('GIVEN a match that begins mid-token after an apostrophe WHEN createSafeFixInfo runs THEN the fix is rejected', () => {
+      // Simulates a path pattern starting at "t/wait/..." inside "don't/wait/...".
+      const original = 't/wait/wrong/undo/actually';
+      const line = "The sequence stop/don't/wait/wrong/undo/actually is prose.";
+      const result = createSafeFixInfo(
+        { editColumn: 1, deleteCount: original.length, insertText: `\`${original}\`` },
+        'backtick',
+        original,
+        `\`${original}\``,
+        { type: 'code-element', line }
+      );
+      expect(result).toBeNull();
+    });
+
+    test('GIVEN a genuine file path WHEN createSafeFixInfo runs THEN the fix is allowed', () => {
+      const original = 'src/index.js';
+      const line = `Edit ${original} to change it.`;
+      const result = createSafeFixInfo(
+        { editColumn: 6, deleteCount: original.length, insertText: `\`${original}\`` },
+        'backtick',
+        original,
+        `\`${original}\``,
+        { type: 'code-element', line }
+      );
+      expect(result).not.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add a corruption guard to the autofix-safety layer that rejects content-damaging BCE001 fixes
- Bare URLs (scheme- or `www.`-prefixed) are no longer wrapped in code spans
- Fixes that would insert a backtick partway through a prose token are rejected
- Skipped corrupting fixes are recorded via existing telemetry

Closes #234

## Test plan

### Automated testing
- [x] New regression + unit tests in `tests/features/autofix-corruption-guard.test.js`
- [x] Autofix and backtick suites pass (332 tests)
- [x] Full Jest suite passes (one unrelated, untracked `docs-consistency` ADR check excepted)

### Manual testing
- [x] `--fix` leaves `stop/don't/wait/...` prose untouched
- [x] `--fix` leaves bare `https://` and `www.` URLs untouched
- [x] Genuine code elements (`git status`, `src/index.js`) still get backticked

### Test coverage
- [x] New behavior has tests
- [x] Tests follow behavioral GIVEN/WHEN/THEN naming

## Breaking changes

None — backward compatible; only suppresses previously corrupting autofixes.