### PR TITLE
Fix SC001 first-word and compound-token edge cases

### DIFF
--- a/src/rules/sentence-case/bold-text-classifier.js
+++ b/src/rules/sentence-case/bold-text-classifier.js
@@ -9,8 +9,8 @@
  */
 
 import { isAcronym } from '../shared-heuristics.js';
-import { UNICODE_UPPERCASE_REGEX } from '../shared-constants.js';
-import { validateFirstWord } from './word-validators.js';
+import { UNICODE_UPPERCASE_REGEX, contextualAllCapsTerms } from '../shared-constants.js';
+import { isAcceptableHyphenatedCompound, validateFirstWord } from './word-validators.js';
 import {
   findFirstValidationWord,
   getProperPhraseIndices,
@@ -18,54 +18,6 @@ import {
   prepareTextForValidation,
   validateProperPhrases
 } from './case-classifier.js';
-
-/**
- * Determines whether a hyphenated compound is acceptable in bold text because
- * every segment is individually valid: a lowercase word, the pronoun "I", a
- * short acronym, or a segment whose uppercased form is a configured acronym or
- * special term (e.g. "high-CEFR", "FAQ-shaped", "API-wide"). At least one
- * segment must be a configured term or acronym so ordinary mixed-case compounds
- * like "Bad-Word" are still flagged (#233 Part B.2).
- * @param {string} word The hyphenated token to check.
- * @param {Object} specialCasedTerms Special casing terms dictionary.
- * @returns {boolean} True when the compound should be left alone.
- */
-function isAcceptableHyphenatedCompound(word, specialCasedTerms) {
-  if (!word.includes('-')) {
-    return false;
-  }
-  const segments = word.split('-');
-  if (segments.length < 2) {
-    return false;
-  }
-
-  let sawConfiguredOrAcronym = false;
-  for (const segment of segments) {
-    if (segment === '') {
-      return false;
-    }
-    // Plain lowercase segment is always acceptable.
-    if (segment === segment.toLowerCase()) {
-      continue;
-    }
-    // A segment matching a configured term's exact casing (acronym or proper
-    // noun) is acceptable, e.g. "CEFR", "FAQ", "API", "Saxon".
-    const configured = specialCasedTerms[segment.toLowerCase()];
-    if (configured && segment === configured) {
-      sawConfiguredOrAcronym = true;
-      continue;
-    }
-    // A short all-caps acronym is acceptable even when not explicitly configured.
-    if (isAcronym(segment)) {
-      sawConfiguredOrAcronym = true;
-      continue;
-    }
-    // Any other non-lowercase segment (e.g. "Bad", "Word") is a violation.
-    return false;
-  }
-
-  return sawConfiguredOrAcronym;
-}
 
 /**
  * Performs stricter validation for bold text in list items.
@@ -140,6 +92,14 @@ export function performBoldTextValidation(words, cleanedText, hadLeadingEmoji, s
     // A hyphenated special term (e.g. "Anglo-Saxon") matches as a whole token, so
     // no sub-segment is independently checked for lowercase casing (#233 Part B.2).
     if (expectedWordCasing && word === expectedWordCasing && word.includes('-')) {
+      continue;
+    }
+
+    // Contextual ALL_CAPS terms (NOTE, TIP, CAUTION, etc.) double as ordinary
+    // lowercase prose words. When such a word appears lowercase in a non-first
+    // bold position it is normal prose, not the alert keyword, so it is not
+    // forced to all caps. This mirrors the heading subsequent-word path (#245).
+    if (contextualAllCapsTerms.has(wordLower) && word === word.toLowerCase()) {
       continue;
     }
 

--- a/src/rules/sentence-case/case-classifier.js
+++ b/src/rules/sentence-case/case-classifier.js
@@ -7,7 +7,7 @@
  * All functions return validation results without side effects (no onError calls).
  */
 
-import { preserveSegments } from '../shared-heuristics.js';
+import { isAcronym, preserveSegments } from '../shared-heuristics.js';
 import { escapeRegExp } from '../shared-utils.js';
 import { UNICODE_LETTER_REGEX } from '../shared-constants.js';
 import { validateFirstWord, validateSubsequentWords } from './word-validators.js';
@@ -227,15 +227,29 @@ function validateProperPhrases(text, specialCasedTerms) {
 /**
  * Determine if all non-acronym words are uppercase.
  * @param {string[]} words - Words extracted from the heading.
+ * @param {string} [cleanedText] - The cleaned heading text, used to detect a
+ *   single whitespace-free term that punctuation cleanup split into multiple
+ *   short-acronym tokens (e.g. "TL;DR").
  * @returns {boolean} True when every relevant word is uppercase.
  */
-function isAllCapsHeading(words) {
+function isAllCapsHeading(words, cleanedText) {
   const relevant = words.filter(
     (w) =>
       w.length > 1 &&
       !(w.startsWith('__PRESERVED_') && w.endsWith('__'))
   );
   const allCaps = relevant.filter((w) => w === w.toUpperCase());
+  // A heading that is solely a single whitespace-free term split into short
+  // acronyms by punctuation cleanup (e.g. "TL;DR" -> ["TL", "DR"]) is a known
+  // acronym/term, not shouting prose, so it is not flagged as all caps (#245).
+  if (
+    typeof cleanedText === 'string' &&
+    !/\s/.test(cleanedText.trim()) &&
+    relevant.length > 0 &&
+    relevant.every((w) => isAcronym(w))
+  ) {
+    return false;
+  }
   return (
     relevant.length > 1 &&
     allCaps.length === relevant.length &&
@@ -332,7 +346,7 @@ function performWordValidation(words, cleanedText, phraseIgnore, hadLeadingEmoji
   }
 
   // Check for all caps heading
-  if (isAllCapsHeading(words)) {
+  if (isAllCapsHeading(words, cleanedText)) {
     return {
       isValid: false,
       errorMessage: 'Heading should not be in all caps.'

--- a/src/rules/sentence-case/word-validators.js
+++ b/src/rules/sentence-case/word-validators.js
@@ -80,6 +80,49 @@ export function isCodeIdentifier(word) {
 }
 
 /**
+ * Determines whether a hyphenated compound is acceptable because every segment
+ * is individually valid: a lowercase word, a short acronym, or a segment whose
+ * casing matches a configured acronym or proper noun (e.g. "high-CEFR",
+ * "issue-PR", "FAQ-shaped"). At least one segment must be a configured term or
+ * acronym so ordinary mixed-case compounds like "issue-Relationship" still flag
+ * (#233 Part B.2, extended to the heading subsequent-word path in #245).
+ * @param {string} word The hyphenated token to check.
+ * @param {Object} specialCasedTerms Special casing terms dictionary.
+ * @returns {boolean} True when the compound should be left alone.
+ */
+export function isAcceptableHyphenatedCompound(word, specialCasedTerms) {
+  if (!word.includes('-')) {
+    return false;
+  }
+  const segments = word.split('-');
+  if (segments.length < 2) {
+    return false;
+  }
+
+  let sawConfiguredOrAcronym = false;
+  for (const segment of segments) {
+    if (segment === '') {
+      return false;
+    }
+    if (segment === segment.toLowerCase()) {
+      continue;
+    }
+    const configured = specialCasedTerms[segment.toLowerCase()];
+    if (configured && segment === configured) {
+      sawConfiguredOrAcronym = true;
+      continue;
+    }
+    if (isAcronym(segment)) {
+      sawConfiguredOrAcronym = true;
+      continue;
+    }
+    return false;
+  }
+
+  return sawConfiguredOrAcronym;
+}
+
+/**
  * Validates the first word's capitalization.
  * @param {string} firstWord The first word to validate.
  * @param {number} firstIndex Index of the first word.
@@ -269,6 +312,26 @@ export function validateFirstWord(firstWord, firstIndex, phraseIgnore, specialCa
         return { isValid: true };
       }
 
+      // A hyphenated first word is valid sentence case when its first segment
+      // is a properly capitalized word (satisfying the first-word requirement)
+      // and every later segment is lowercase, a configured proper noun, or an
+      // acronym (e.g. "Word-Markdown", "Non-Italian"). A later segment that is a
+      // plain capitalized word ("Well-Known") is still flagged (#245).
+      if (firstWord.includes('-')) {
+        const segs = firstWord.split('-');
+        const firstSegCapitalized = /^[A-Z][a-z]*$/.test(segs[0]);
+        const restValid = segs.slice(1).every((seg) => {
+          if (seg === '') return false;
+          if (seg === seg.toLowerCase()) return true;
+          const configured = specialCasedTerms[seg.toLowerCase()];
+          if (configured && seg === configured) return true;
+          return isAcronym(seg);
+        });
+        if (firstSegCapitalized && restValid && segs.length > 1) {
+          return { isValid: true };
+        }
+      }
+
       // Regular sentence case
       const expectedSentenceCase = firstWord.charAt(0).toUpperCase() + firstWord.slice(1).toLowerCase();
       if (firstWord !== expectedSentenceCase) {
@@ -434,6 +497,13 @@ export function validateSubsequentWords(words, startIndex, phraseIgnore, special
       const acronymPrefixMatch = /^([A-Z]{2,4}(?:\/[A-Z][a-z]+)?(?:\/[A-Z]{2,})*)(-[a-z].*)$/.exec(word);
       if (acronymPrefixMatch) {
         // This is valid - acronym prefix with lowercase suffix
+        continue;
+      }
+
+      // A compound whose every segment is a lowercase word or a configured
+      // acronym/proper noun (e.g. "high-CEFR", "issue-PR") is acceptable. This
+      // whole-token reasoning previously ran only on the bold path (#245).
+      if (isAcceptableHyphenatedCompound(word, specialCasedTerms)) {
         continue;
       }
 

--- a/tests/features/sentence-case-edge-cases-245.test.js
+++ b/tests/features/sentence-case-edge-cases-245.test.js
@@ -1,0 +1,113 @@
+// @ts-check
+
+/**
+ * Feature tests for SC001 first-word and compound-token edge cases (issue #245).
+ *
+ * A second consumer-corpus audit (after #233 and #235) surfaced remaining
+ * false positives. Each heading/label below is correctly cased but was still
+ * flagged. Every case must produce no SC001 error, and a paired true-positive
+ * guard proves genuine violations still flag.
+ */
+
+import { describe, test, expect } from '@jest/globals';
+import { lint } from 'markdownlint/promise';
+import sentenceRule from '../../src/rules/sentence-case-heading.js';
+
+/**
+ * Lint markdown content with the SC001 rule and a given config.
+ * @param {string} content Markdown content to lint.
+ * @param {Object} config sentence-case-heading configuration.
+ * @returns {Promise<object[]>} SC001 violations with fixInfo (actual errors).
+ */
+async function lintMarkdown(content, config = {}) {
+  const options = {
+    customRules: [sentenceRule],
+    strings: { testContent: content },
+    config: {
+      default: false,
+      'sentence-case-heading': config
+    },
+    resultVersion: 3
+  };
+  const results = await lint(options);
+  return (results.testContent || []).filter(
+    (v) =>
+      (v.ruleNames.includes('sentence-case-heading') ||
+        v.ruleNames.includes('SC001')) &&
+      v.fixInfo != null
+  );
+}
+
+describe('SC001 hyphenated capitalized first word (issue #245)', () => {
+  test('test_should_not_flag_proper_noun_hyphen_first_word_in_heading', async () => {
+    const violations = await lintMarkdown('## Word-Markdown converter');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_capitalized_hyphen_first_word_in_bold', async () => {
+    const violations = await lintMarkdown('- **Non-Italian menus** are listed');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_still_flag_lowercase_first_word_in_heading', async () => {
+    const violations = await lintMarkdown('## converter for documents');
+    expect(violations.length).toBeGreaterThan(0);
+  });
+});
+
+describe('SC001 all-caps single-term heading (issue #245)', () => {
+  test('test_should_not_flag_acronym_only_heading_with_punctuation', async () => {
+    const violations = await lintMarkdown('## TL;DR');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_still_flag_multi_word_all_caps_heading', async () => {
+    const violations = await lintMarkdown('## THIS IS SHOUTING LOUDLY');
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0].errorDetail).toMatch(/all caps/i);
+  });
+});
+
+describe('SC001 hyphenated compound in subsequent heading words (issue #245)', () => {
+  test('test_should_not_flag_acronym_segment_in_subsequent_hyphen_compound', async () => {
+    const violations = await lintMarkdown('## Common high-CEFR words', {
+      acronyms: ['CEFR']
+    });
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_acronym_segment_when_replacing_vocabulary', async () => {
+    const violations = await lintMarkdown('## Replace high-CEFR vocabulary', {
+      acronyms: ['CEFR']
+    });
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_default_acronym_segment_in_subsequent_compound', async () => {
+    const violations = await lintMarkdown('## Extract issue-PR relationships');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_still_flag_capitalized_segment_in_subsequent_compound', async () => {
+    const violations = await lintMarkdown('## Extract issue-Relationship maps');
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0].errorDetail).toMatch(/lowercase/i);
+  });
+});
+
+describe('SC001 contextualAllCaps not forced in ordinary prose (issue #245)', () => {
+  test('test_should_not_flag_alert_keyword_in_lowercase_bold_prose', async () => {
+    const violations = await lintMarkdown('- **Proceed with caution** when deleting');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_other_alert_keywords_in_lowercase_bold_prose', async () => {
+    const violations = await lintMarkdown('- **Read the note carefully** before warning users');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_still_flag_genuine_all_caps_in_bold_prose', async () => {
+    const violations = await lintMarkdown('- **Common PATTERNS reference** here');
+    expect(violations.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes six residual SC001 sentence-case false positives surfaced by a consumer-corpus audit
- Accepts capitalized hyphenated first words with valid suffixes (`Word-Markdown`, `Non-Italian`)
- Exempts single-term all-caps headings like `TL;DR` from the all-caps check
- Applies the whole-hyphenated-token compound match (from #233) on the heading subsequent-word path so `high-CEFR` and `issue-PR` are accepted
- Stops forcing contextual all-caps terms (`caution`, `note`, etc.) to uppercase when used as ordinary lowercase bold prose
- Shares `isAcceptableHyphenatedCompound` between the heading and bold paths

Closes #245

## Test plan

### Automated testing
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Full test suite passes (1672 passed, 9 skipped)

### Manual testing
- [x] Tested with representative headings and bold list items
- [x] Edge cases verified (true-positive guards still flag `Well-Known`, `issue-Relationship`, multi-word all-caps, genuine all-caps bold)

### Test coverage
- [x] New functionality has tests (`tests/features/sentence-case-edge-cases-245.test.js`)
- [x] Tests follow behavioral naming

## Breaking changes

None — backward compatible; reduces false positives only.

## Documentation

- [x] Docstrings added for new shared helper `isAcceptableHyphenatedCompound`
- [ ] API documentation updated if public APIs added or changed *(optional)*
- [ ] README updated if public-facing behavior changed *(optional)*
