### PR TITLE
Fix autofix targeting wrong span for duplicate bold text

### DIFF
--- a/src/rules/sentence-case-heading.js
+++ b/src/rules/sentence-case-heading.js
@@ -211,8 +211,10 @@ function basicSentenceCaseHeadingFunction(params, onError) {
    * @param {string} boldText - Bold text in question.
    * @param {string} line - Original source line.
    * @param {string} textForValidation - Text that was validated (may be truncated if ignoreAfterEmoji).
+   * @param {number} [matchStart=0] - Offset of the flagged bold span in the line, used to
+   *   disambiguate the occurrence when the same bold phrase appears more than once.
    */
-  function reportForBoldText(detail, lineNumber, boldText, line, textForValidation) {
+  function reportForBoldText(detail, lineNumber, boldText, line, textForValidation, matchStart = 0) {
     // If ignoreAfterEmoji is enabled and text was truncated, only fix the part before emoji
     const fixTarget = (ignoreAfterEmoji && textForValidation) ? textForValidation : boldText;
     const fixedText = toSentenceCase(fixTarget, specialCasedTerms, effectiveAmbiguousTerms);
@@ -221,7 +223,7 @@ function basicSentenceCaseHeadingFunction(params, onError) {
       lineNumber,
       detail,
       context: `**${textForValidation || boldText}**`,
-      fixInfo: fixedText ? buildBoldTextFix(line, fixTarget, fixedText, safetyConfig) : undefined
+      fixInfo: fixedText ? buildBoldTextFix(line, fixTarget, fixedText, safetyConfig, matchStart) : undefined
     });
   }
 
@@ -230,8 +232,9 @@ function basicSentenceCaseHeadingFunction(params, onError) {
    * @param {string} boldText The bold text to validate.
    * @param {number} lineNumber The line number of the text.
    * @param {string} sourceLine The full source line.
+   * @param {number} [matchStart=0] Offset of the bold span within sourceLine.
    */
-  function validateBoldTextInContext(boldText, lineNumber, sourceLine) {
+  function validateBoldTextInContext(boldText, lineNumber, sourceLine, matchStart = 0) {
     if (!boldText || !boldText.trim()) {
       return;
     }
@@ -247,7 +250,7 @@ function basicSentenceCaseHeadingFunction(params, onError) {
     const validationResult = validateBoldText(textForValidation, specialCasedTerms, effectiveAmbiguousTerms);
 
     if (!validationResult.isValid) {
-      reportForBoldText(validationResult.errorMessage, lineNumber, boldText, sourceLine, textForValidation);
+      reportForBoldText(validationResult.errorMessage, lineNumber, boldText, sourceLine, textForValidation, matchStart);
     }
   }
 
@@ -376,8 +379,9 @@ function basicSentenceCaseHeadingFunction(params, onError) {
       // Skip empty text
       if (!textToValidate) continue;
 
-      // Use the unified validation logic
-      validateBoldTextInContext(textToValidate, lineNumber, line);
+      // Use the unified validation logic; pass the span offset so the autofix
+      // targets this occurrence even if the same bold phrase repeats on the line.
+      validateBoldTextInContext(textToValidate, lineNumber, line, matchStart);
 
       // Only validate the first bold text in the list item (which we already confirmed is at the start)
       break;

--- a/tests/features/sentence-case-duplicate-bold-221.test.js
+++ b/tests/features/sentence-case-duplicate-bold-221.test.js
@@ -1,0 +1,64 @@
+/**
+ * @integration
+ *
+ * Regression coverage for #221: buildBoldTextFix located the bold span with a
+ * plain indexOf, so a duplicate bold phrase on one line could have the wrong
+ * occurrence rewritten. The rule caller now threads the matched span offset
+ * through to buildBoldTextFix so the flagged occurrence is the one fixed.
+ */
+import { describe, test, expect } from "@jest/globals";
+import { lint } from "markdownlint/promise";
+import { applyFixes } from "markdownlint";
+import sentenceRule from "../../src/rules/sentence-case-heading.js";
+
+/**
+ * Lint a single markdown string with the sentence-case rule.
+ * @param {string} content - Markdown to lint.
+ * @returns {Promise<Array>} Sentence-case violations for the content.
+ */
+async function lintContent(content) {
+  const results = await lint({
+    customRules: [sentenceRule],
+    strings: { content },
+    resultVersion: 3,
+    fix: false,
+  });
+  return (results.content || []).filter(
+    (v) =>
+      v.ruleNames.includes("sentence-case-heading") ||
+      v.ruleNames.includes("SC001"),
+  );
+}
+
+describe("sentence-case duplicate bold autofix (#221)", () => {
+  test("test_should_fix_flagged_span_when_duplicate_bold_phrase_on_line", async () => {
+    const content = "- **Bold Text** and **Bold Text** more\n";
+
+    const violations = await lintContent(content);
+    expect(violations.length).toBeGreaterThan(0);
+
+    // The flagged violation must carry a fixInfo whose editColumn points at the
+    // bold span the rule actually validated. Applying the fix must produce a
+    // well-formed line — never a corrupted span from rewriting the wrong half.
+    const fixed = applyFixes(content, violations);
+    expect(fixed).toBe("- **Bold text** and **Bold Text** more\n");
+  });
+
+  test("test_should_anchor_editColumn_to_validated_span_offset", async () => {
+    // Leading emoji shifts the validated span off column 0, exercising a
+    // non-zero offset path through the caller -> buildBoldTextFix threading.
+    const content = "- 🚀 **Bold Text** and **Bold Text** end\n";
+
+    const violations = await lintContent(content);
+    expect(violations).toHaveLength(1);
+
+    const { fixInfo } = violations[0];
+    expect(fixInfo).toBeDefined();
+    // The validated span is the first "**Bold Text**"; its opening "**" begins
+    // at offset 4 (after "- 🚀 " where the emoji is two UTF-16 code units),
+    // so editColumn lands just past it. Assert it matches the real offset
+    // rather than a hard-coded indexOf assumption.
+    const expectedColumn = content.indexOf("**Bold Text**") + 3;
+    expect(fixInfo.editColumn).toBe(expectedColumn);
+  });
+});

--- a/tests/unit/sentence-case-fix-builder.test.js
+++ b/tests/unit/sentence-case-fix-builder.test.js
@@ -338,4 +338,27 @@ describe("buildBoldTextFix", () => {
     const second = buildBoldTextFix(line, originalBoldText, fixedBoldText, defaultSafetyConfig, 13);
     expect(second.editColumn).toBe(21); // position 18 + 3
   });
+
+  test("test_should_target_flagged_occurrence_when_duplicate_bold_on_line", () => {
+    // Regression for #221: when the same bold phrase appears twice on one line
+    // and the SECOND occurrence is the flagged violation, the fix must rewrite
+    // that span — not the first one indexOf would otherwise return.
+    const line = "- **Foo Bar** and **Foo Bar** end";
+    const originalBoldText = "Foo Bar";
+    const fixedBoldText = "Foo bar";
+
+    const secondOccurrence = line.indexOf("**Foo Bar**", 5);
+    const result = buildBoldTextFix(
+      line,
+      originalBoldText,
+      fixedBoldText,
+      defaultSafetyConfig,
+      secondOccurrence,
+    );
+
+    // editColumn is 1-based and points just after the opening "**" of the
+    // SECOND occurrence (offset 18), so 18 + 3 = 21.
+    expect(result).toBeDefined();
+    expect(result.editColumn).toBe(21);
+  });
 });


### PR DESCRIPTION
## Summary

- `buildBoldTextFix` located the bold span with a plain `indexOf`, so when the same bold phrase appeared more than once on a line, the autofix could rewrite the wrong occurrence.
- The rule caller now threads the matched span offset from the bold-match loop through `validateBoldTextInContext` and `reportForBoldText` into `buildBoldTextFix` as `startIndex`, so the fix always targets the flagged occurrence.

Closes #221

## Test plan

### Automated testing
- [x] New unit regression in `tests/unit/sentence-case-fix-builder.test.js` asserts the second occurrence is targeted when a bold phrase repeats.
- [x] New feature regression in `tests/features/sentence-case-duplicate-bold-221.test.js` lints duplicate and emoji-offset bold spans through the full rule pipeline and verifies the correct span is rewritten.
- [x] Full sentence-case suite passes (463 tests).
- [x] `npx eslint` clean on changed files.

### Test coverage
- [x] New behavior has both unit and feature tests.
- [x] Tests follow behavioral naming.

## Breaking changes

None — backward compatible. The new caller argument defaults to `0`, preserving prior behavior.