### PR TITLE
Retain Unicode letters in DL001 heading-anchor slug

### DIFF
--- a/src/rules/no-dead-internal-links.js
+++ b/src/rules/no-dead-internal-links.js
@@ -30,8 +30,8 @@ const contentCache = new Map(); // filepath -> string (file content)
 
 /**
  * Convert a heading text to an anchor format used in GitHub-flavored markdown.
- * Follows GitHub's punctuation handling (strip, don't hyphenate); note that
- * accented Latin letters are dropped here whereas GitHub retains them.
+ * Follows GitHub's punctuation handling (strip, don't hyphenate) and retains
+ * Unicode letters such as accented Latin characters, matching GitHub.
  * @param {string} heading - The heading text
  * @returns {string} The anchor-formatted heading
  */
@@ -43,10 +43,11 @@ function headingToAnchor(heading) {
     .replace(/<[^>]+>/g, '')
     // Remove markdown formatting
     .replace(/[*_`[\]]/g, '')
-    // Remove every character that is not a word char, CJK, whitespace, or hyphen.
-    // GitHub (and markdownlint MD051) strips punctuation rather than hyphenating it,
+    // Remove every character that is not a Unicode letter, number, mark,
+    // underscore, whitespace, or hyphen. GitHub keeps accented Latin letters
+    // (Di\u00e1taxis -> di\u00e1taxis) but strips punctuation rather than hyphenating it,
     // so "evals.json" becomes "evalsjson" and "don't" becomes "dont".
-    .replace(/[^\w\u4e00-\u9fa5\s-]+/g, '')
+    .replace(/[^\p{L}\p{N}\p{M}_\s-]+/gu, '')
     // Collapse runs of whitespace into single hyphens
     .replace(/\s+/g, '-')
     // Remove leading/trailing hyphens
@@ -506,5 +507,6 @@ export default {
 // Re-export for test compatibility; prefer the named export `clearCaches` in new code
 export const _forTesting = {
   clearCaches,
-  getCacheStats
+  getCacheStats,
+  headingToAnchor
 };

--- a/tests/unit/heading-to-anchor.test.js
+++ b/tests/unit/heading-to-anchor.test.js
@@ -1,0 +1,22 @@
+import { _forTesting } from '../../src/rules/no-dead-internal-links.js';
+
+const { headingToAnchor } = _forTesting;
+
+describe('headingToAnchor', () => {
+  test('should retain accented Unicode letters like GitHub', () => {
+    expect(headingToAnchor('Diátaxis')).toBe('diátaxis');
+  });
+
+  test('should retain accents within a multi-word heading', () => {
+    expect(headingToAnchor('Classify Diátaxis type')).toBe('classify-diátaxis-type');
+  });
+
+  test('should keep ASCII slug behavior unchanged', () => {
+    expect(headingToAnchor('evals.json')).toBe('evalsjson');
+    expect(headingToAnchor("don't")).toBe('dont');
+  });
+
+  test('should collapse whitespace into hyphens and strip punctuation', () => {
+    expect(headingToAnchor('Hello World!')).toBe('hello-world');
+  });
+});


### PR DESCRIPTION
## Summary

- Fix DL001 heading-anchor slug to retain Unicode letters (accented Latin) like GitHub
- `Classify Diátaxis type` now slugs to `classify-diátaxis-type`, so valid anchor links resolve
- ASCII punctuation stripping is unchanged (`evals.json` -> `evalsjson`, `don't` -> `dont`)

Closes #246

## Test plan

### Automated testing
- [x] New unit tests `tests/unit/heading-to-anchor.test.js` cover accented headings and ASCII regression
- [x] Existing feature suite `tests/features/no-dead-internal-links.test.js` passes (70 tests)
- [x] `npm run lint` clean on changed files

### Test coverage
- [x] New behavior has tests (accent retention + ASCII unchanged)
- [x] Tests follow behavioral naming
