### PR TITLE
Add repo-root link resolution to DL001

### DIFF
--- a/src/rules/config-validation.js
+++ b/src/rules/config-validation.js
@@ -126,6 +126,57 @@ export function validateNonNegativeNumber(value, fieldName) {
 }
 
 /**
+ * Validates that a value is a string.
+ * @param {any} value - The value to validate
+ * @param {string} fieldName - Name of the configuration field
+ * @returns {ValidationError[]} Array of validation errors (empty if valid)
+ */
+export function validateString(value, fieldName) {
+  const errors = [];
+
+  if (value === undefined || value === null) {
+    return errors; // Allow undefined/null values (optional fields)
+  }
+
+  if (typeof value !== 'string') {
+    errors.push({
+      field: fieldName,
+      message: `${fieldName} must be a string`,
+      value: value,
+      expected: 'string'
+    });
+  }
+
+  return errors;
+}
+
+/**
+ * Creates a validator that requires the value to be one of the allowed strings.
+ * @param {string[]} allowed - Permitted string values
+ * @returns {function(any, string): ValidationError[]} Validator function
+ */
+export function validateEnum(allowed) {
+  return function(value, fieldName) {
+    const errors = [];
+
+    if (value === undefined || value === null) {
+      return errors; // Allow undefined/null values (optional fields)
+    }
+
+    if (typeof value !== 'string' || !allowed.includes(value)) {
+      errors.push({
+        field: fieldName,
+        message: `${fieldName} must be one of: ${allowed.join(', ')}`,
+        value: value,
+        expected: `one of: ${allowed.join(', ')}`
+      });
+    }
+
+    return errors;
+  };
+}
+
+/**
  * Formats validation errors into a user-friendly message.
  * @param {string} ruleName - Name of the rule being configured
  * @param {ValidationError[]} errors - Array of validation errors

--- a/src/rules/no-dead-internal-links.js
+++ b/src/rules/no-dead-internal-links.js
@@ -13,10 +13,12 @@
 
 import fs from 'fs';
 import path from 'path';
-import { 
-  validateStringArray, 
+import {
+  validateStringArray,
   validateBoolean,
-  validateConfig, 
+  validateString,
+  validateEnum,
+  validateConfig,
   logValidationErrors,
   createMarkdownlintLogger
 } from './config-validation.js';
@@ -109,6 +111,40 @@ function extractHeadings(content) {
 function resolvePath(currentFile, linkPath) {
   const dir = path.dirname(currentFile);
   return path.resolve(dir, linkPath);
+}
+
+// Cache resolved repo roots per starting directory to avoid repeated upward
+// filesystem walks within a single lint run.
+const repoRootCache = new Map(); // startDir -> string|null
+
+/**
+ * Detect the repository root by walking up from a starting directory until a
+ * `.git` entry is found. Returns null when no marker is found before the
+ * filesystem root.
+ * @param {string} startDir - Directory to start searching from
+ * @returns {string|null} Absolute path to the repo root, or null
+ */
+function detectRepoRoot(startDir) {
+  if (repoRootCache.has(startDir)) {
+    return repoRootCache.get(startDir);
+  }
+
+  let dir = startDir;
+  let found = null;
+  while (true) {
+    if (fileExists(path.join(dir, '.git'))) {
+      found = dir;
+      break;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+
+  repoRootCache.set(startDir, found);
+  return found;
 }
 
 /**
@@ -275,7 +311,9 @@ function noDeadInternalLinks(params, onError) {
     checkAnchors: validateBoolean,
     allowedExtensions: validateStringArray,
     allowPlaceholders: validateBoolean,
-    placeholderPatterns: validateStringArray
+    placeholderPatterns: validateStringArray,
+    linkBase: validateEnum(['file', 'root']),
+    repoRoot: validateString
   };
 
   const validationResult = validateConfig(config, configSchema, 'no-dead-internal-links');
@@ -290,6 +328,10 @@ function noDeadInternalLinks(params, onError) {
   const checkAnchors = typeof config.checkAnchors === 'boolean' ? config.checkAnchors : true;
   const allowedExtensions = Array.isArray(config.allowedExtensions) ? config.allowedExtensions : ['.md', '.markdown'];
   const allowPlaceholders = typeof config.allowPlaceholders === 'boolean' ? config.allowPlaceholders : true;
+  const linkBase = config.linkBase === 'root' ? 'root' : 'file';
+  const configuredRepoRoot = typeof config.repoRoot === 'string' && config.repoRoot.trim() !== ''
+    ? config.repoRoot
+    : null;
   const placeholderPatterns = Array.isArray(config.placeholderPatterns)
     ? config.placeholderPatterns
     : [
@@ -309,6 +351,17 @@ function noDeadInternalLinks(params, onError) {
   // Skip if we don't have a valid file path
   if (!currentFile || currentFile.includes('<stdin>')) {
     return;
+  }
+
+  // When linkBase is "root", resolve non-anchor links from the repo root
+  // (explicitly configured, or auto-detected by walking up for a .git marker)
+  // rather than from the current file's directory. Falls back to file-relative
+  // resolution when no root can be determined.
+  let linkBaseDir = null;
+  if (linkBase === 'root') {
+    linkBaseDir = configuredRepoRoot
+      ? path.resolve(configuredRepoRoot)
+      : detectRepoRoot(path.dirname(currentFile));
   }
 
   // PERFORMANCE: Pre-extract current file headings once for same-page anchor validation
@@ -393,8 +446,11 @@ function noDeadInternalLinks(params, onError) {
           continue;
         }
 
-        // Resolve the relative path
-        const resolvedPath = resolvePath(currentFile, filePath);
+        // Resolve the relative path. Under linkBase "root", non-absolute links
+        // resolve from the repo root; otherwise from the current file's dir.
+        const resolvedPath = linkBaseDir && !path.isAbsolute(filePath)
+          ? path.resolve(linkBaseDir, filePath)
+          : resolvePath(currentFile, filePath);
         
         // Check if it's a directory link (ends with /)
         const isDirectory = filePath.endsWith('/');
@@ -479,6 +535,7 @@ export function clearCaches() {
   fileExistenceCache.clear();
   headingCache.clear();
   contentCache.clear();
+  repoRootCache.clear();
 }
 
 /**

--- a/tests/features/no-dead-internal-links.test.js
+++ b/tests/features/no-dead-internal-links.test.js
@@ -1076,6 +1076,87 @@ Another paragraph.
       expect(errors[0].detail).toContain('Link target "dir/Missing File.md" does not exist');
     });
   });
+
+  describe('linkBase configuration (DL001 #237)', () => {
+    let repoRoot;
+    let nestedFile;
+
+    beforeEach(() => {
+      repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dl001-linkbase-'));
+      // Mark this directory as a repo root so auto-detection finds it.
+      fs.mkdirSync(path.join(repoRoot, '.git'));
+      // Root-relative target.
+      fs.mkdirSync(path.join(repoRoot, 'docs', 'design'), { recursive: true });
+      fs.writeFileSync(path.join(repoRoot, 'docs', 'design', 'x.md'), '# X\n');
+      // Source file lives in a nested subdirectory.
+      const nestedDir = path.join(repoRoot, 'a', 'b');
+      fs.mkdirSync(nestedDir, { recursive: true });
+      nestedFile = path.join(nestedDir, 'source.md');
+      fs.writeFileSync(nestedFile, '# Source\n');
+      clearCaches();
+    });
+
+    afterEach(() => {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+      clearCaches();
+    });
+
+    test('resolves root-relative link against repo root when linkBase is "root"', () => {
+      const markdown = '[design](docs/design/x.md)';
+      const errors = runRuleWithContent(markdown, nestedFile, { linkBase: 'root' });
+      expect(errors).toHaveLength(0);
+    });
+
+    test('reports the same root-relative link as dead under default file base', () => {
+      const markdown = '[design](docs/design/x.md)';
+      const errors = runRuleWithContent(markdown, nestedFile, {});
+      expect(errors).toHaveLength(1);
+      expect(errors[0].detail).toContain('Link target "docs/design/x.md" does not exist');
+    });
+
+    test('honors an explicit repoRoot over auto-detection', () => {
+      const markdown = '[design](docs/design/x.md)';
+      const errors = runRuleWithContent(markdown, nestedFile, {
+        linkBase: 'root',
+        repoRoot
+      });
+      expect(errors).toHaveLength(0);
+    });
+
+    test('still reports a genuinely missing target under linkBase "root"', () => {
+      const markdown = '[missing](docs/design/missing.md)';
+      const errors = runRuleWithContent(markdown, nestedFile, { linkBase: 'root' });
+      expect(errors).toHaveLength(1);
+      expect(errors[0].detail).toContain('Link target "docs/design/missing.md" does not exist');
+    });
+
+    test('leaves same-page anchors unaffected by linkBase', () => {
+      const markdown = '# Source\n\n[self](#source)';
+      const errors = runRuleWithContent(markdown, nestedFile, { linkBase: 'root' });
+      expect(errors).toHaveLength(0);
+    });
+
+    test('config validation accepts linkBase and repoRoot keys', () => {
+      const markdown = '[design](docs/design/x.md)';
+      const errors = runRuleWithContent(markdown, nestedFile, {
+        linkBase: 'root',
+        repoRoot
+      });
+      const validationErrors = errors.filter(e =>
+        /Configuration validation failed|Unknown configuration option/.test(e.detail || '')
+      );
+      expect(validationErrors).toHaveLength(0);
+    });
+
+    test('config validation rejects an invalid linkBase value', () => {
+      const markdown = '[design](docs/design/x.md)';
+      const errors = runRuleWithContent(markdown, nestedFile, { linkBase: 'nonsense' });
+      const validationErrors = errors.filter(e =>
+        /Configuration validation failed/.test(e.detail || '')
+      );
+      expect(validationErrors.length).toBeGreaterThan(0);
+    });
+  });
 });
 
 describe('watch-mode stale cache (NIL001 #204)', () => {


### PR DESCRIPTION
## Summary

- Add `linkBase: "file" | "root"` (default `"file"`) to the `no-dead-internal-links` (DL001) rule
- When `linkBase: "root"`, non-anchor links resolve from the repo root instead of the file's directory
- Repo root is auto-detected by walking up for a `.git` marker, or set explicitly via `repoRoot`
- Add `validateString` and `validateEnum` config validators so the new keys validate cleanly

Closes #237

## Test plan

### Automated testing
- [x] Unit/feature tests pass (`npm test -- tests/features/no-dead-internal-links.test.js tests/features/config-validation.test.js`)
- [x] New `linkBase` tests cover root resolution, default file base, explicit `repoRoot`, missing targets, anchors, and config validation

### Manual testing
- [x] Default behavior unchanged: root-relative link still reported dead under default `"file"` base

### Test coverage
- [x] New functionality has tests
- [x] Tests follow behavioral naming

## Breaking changes

None — default `linkBase` is `"file"`, preserving existing behavior.

## Documentation

- [ ] *(optional)* docs/rules.md reference for `linkBase` — follow-up
