### PR TITLE
Add date-time-consistency rule for weekday and timezone validation

### DIFF
--- a/basic-config.jsonc
+++ b/basic-config.jsonc
@@ -14,7 +14,10 @@
 
     // Enable a small, high-signal set of custom rules
     "sentence-case-heading": true,
-    "backtick-code-elements": true
+    "backtick-code-elements": true,
+
+    // Off by default; opt in via recommended/strict presets
+    "date-time-consistency": false
   }
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,6 +141,19 @@ Fixable: Yes (replace `&` with `and`).
 
 ---
 
+## `date-time-consistency` (DTC001)
+
+- `timezone`: string (default: `America/New_York`) — IANA timezone the numbered date is interpreted in.
+- `defaultYear`: number | null (default: `null`) — Year assumed when a date omits it; `null` uses the current year.
+
+Off by default in the `basic` preset; on in `recommended` and `strict`.
+
+Fixable: Yes for weekday, abbreviation, and offset mismatches. DST transition edge hours (skipped or ambiguous) are flagged lint-only.
+
+See the [rule reference](rules.md) for the validation model and examples.
+
+---
+
 ## Autofix safety tuning
 
 markdownlint-trap uses a three-tier confidence system to determine autofix safety.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -15,6 +15,7 @@ Each custom rule's behavior, ID, and fixability. See `docs/configuration.md` for
 | `no-dead-internal-links` | DL001 | No | Validate internal file links and heading anchors |
 | `no-literal-ampersand` | NLA001 | Yes | Replace standalone `&` with "and" in prose |
 | `no-empty-list-items` | ELI001 | Yes | Remove empty list items (Word conversion artifacts) |
+| `date-time-consistency` | DTC001 | Yes | Validate weekdays, `EST`/`EDT`, and UTC offsets against the date |
 
 ---
 
@@ -234,6 +235,41 @@ Examples
 
 - Good: `- Item with content`
 - Bad: `-` (marker followed by whitespace only)
+
+---
+
+## `date-time-consistency` (DTC001)
+
+Validates written weekdays, `EST`/`EDT` style abbreviations, and `(UTC±n)` offsets against the numbered calendar date in a configured IANA timezone. The numbered date is authoritative.
+
+- Parses `[<Weekday>,] <Month> <Day>[, <Year>]` in full and abbreviated forms, with ordinal suffixes (`15th`).
+- Binds each time phrase (`<hh>[:<mm>] <AM|PM> <abbr>[ (UTC±n)]`) to the nearest preceding date on the line.
+- Validates and auto-fixes three facts from the date: the weekday, the DST abbreviation (`EST`/`EDT`), and the UTC offset (`EST` = `UTC-5`, `EDT` = `UTC-4`).
+- Flags daylight-saving transition edge hours as lint-only (no auto-fix): the skipped hour on spring-forward (does not exist) and the repeated hour on fall-back (ambiguous). The correct adjacent time is author-dependent.
+- Skips dates inside fenced code blocks, inline code, and frontmatter.
+- When a year is omitted, assumes `defaultYear` (or the current year when `null`) and notes the assumption in the finding.
+- Zone resolution uses `Intl.DateTimeFormat`; no timezone-data dependency.
+
+Configuration options
+
+```jsonc
+{
+  "date-time-consistency": {
+    "timezone": "America/New_York",  // IANA zone (default: America/New_York)
+    "defaultYear": null              // null = current year when year omitted
+  }
+}
+```
+
+Off by default in the `basic` preset; on in `recommended` and `strict`.
+
+Examples
+
+- Good: `Saturday, November 15, 2025, at 3:00 PM EST (UTC-5)`
+- Bad (weekday): `Thursday, November 15, 2025` (November 15, 2025 is a Saturday)
+- Bad (abbreviation + offset): `Saturday, November 15, 2025, at 3:00 PM EDT (UTC-4)` (November is `EST (UTC-5)`)
+- Lint-only (skipped hour): `Sunday, March 9, 2025, at 2:30 AM EDT`
+- Lint-only (ambiguous hour): `Sunday, November 2, 2025, at 1:30 AM EDT`
 
 ---
 

--- a/recommended-config.jsonc
+++ b/recommended-config.jsonc
@@ -45,6 +45,12 @@
     "no-bare-url": true,
     "no-dead-internal-links": true,
     "no-literal-ampersand": true,
-    "no-empty-list-items": true
+    "no-empty-list-items": true,
+    "date-time-consistency": {
+      // Numbered dates are authoritative; weekdays, EST/EDT, and UTC offsets
+      // are validated and fixed against this IANA zone.
+      "timezone": "America/New_York",
+      "defaultYear": null
+    }
   }
 }

--- a/scripts/generate-config-docs.js
+++ b/scripts/generate-config-docs.js
@@ -81,6 +81,19 @@ const RULE_METADATA = {
         '[Broken Link](nonexistent.md)'
       ]
     }
+  },
+  'date-time-consistency': {
+    description: 'Validates weekdays, timezone abbreviations, and UTC offsets against the numbered calendar date',
+    examples: {
+      valid: [
+        'Saturday, November 15, 2025, at 3:00 PM EST (UTC-5)',
+        'Wednesday, January 1, 2025'
+      ],
+      invalid: [
+        'Thursday, November 15, 2025',
+        'Saturday, November 15, 2025, at 3:00 PM EDT (UTC-4)'
+      ]
+    }
   }
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import noBareUrls from './rules/no-bare-urls.js';
 import noDeadInternalLinks from './rules/no-dead-internal-links.js';
 import noLiteralAmpersand from './rules/no-literal-ampersand.js';
 import noEmptyListItems from './rules/no-empty-list-items.js';
+import dateTimeConsistency from './rules/date-time-consistency.js';
 
 // Export incremental linting cache
 export { cachedLint } from './cache/cached-lint.js';
@@ -24,4 +25,4 @@ export {
  * Export all custom rules as a single array for markdownlint.
  * @type {import('markdownlint').Rule[]}
  */
-export default [backtickCodeElements, sentenceCaseHeading, noBareUrls, noDeadInternalLinks, noLiteralAmpersand, noEmptyListItems];
+export default [backtickCodeElements, sentenceCaseHeading, noBareUrls, noDeadInternalLinks, noLiteralAmpersand, noEmptyListItems, dateTimeConsistency];

--- a/src/rules/date-time-consistency.js
+++ b/src/rules/date-time-consistency.js
@@ -1,0 +1,524 @@
+// @ts-check
+
+/**
+ * Rule that validates written weekdays, timezone abbreviations, and UTC offsets
+ * against the numbered calendar date they accompany.
+ *
+ * The numbered date (`<Month> <Day>[, <Year>]`) is treated as the single
+ * authoritative source when a timezone is pinned. Weekday names, `EST`/`EDT`
+ * style abbreviations, and `(UTC[+-]n)` offsets are checked and auto-fixed from
+ * that date. Hours that fall on a daylight-saving transition (the skipped hour
+ * on spring-forward, the repeated hour on fall-back) are flagged lint-only
+ * because the intended adjacent time is author-dependent.
+ *
+ * Zone resolution uses `Intl.DateTimeFormat` with the configured IANA zone, so
+ * no runtime timezone-data dependency is required and any zone is supported.
+ */
+
+import {
+  validateString,
+  validateConfig,
+  logValidationErrors,
+  createMarkdownlintLogger,
+} from './config-validation.js';
+import { buildLineContext } from './shared-context.js';
+
+const WEEKDAYS = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+];
+
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+/** Map both full and three-letter month names to a 1-based month number. */
+const MONTH_INDEX = (() => {
+  const map = new Map();
+  MONTHS.forEach((name, i) => {
+    map.set(name.toLowerCase(), i + 1);
+    map.set(name.slice(0, 3).toLowerCase(), i + 1);
+  });
+  return map;
+})();
+
+const WEEKDAY_FULL = WEEKDAYS.join('|');
+const WEEKDAY_ABBR = WEEKDAYS.map((d) => d.slice(0, 3)).join('|');
+const MONTH_FULL = MONTHS.join('|');
+const MONTH_ABBR = MONTHS.map((m) => m.slice(0, 3)).join('|');
+
+/**
+ * Match a date phrase: optional weekday, month, day (with optional ordinal),
+ * and optional year.
+ *
+ * Groups: 1 weekday, 2 month, 3 day, 4 year.
+ */
+const DATE_RE = new RegExp(
+  `\\b(?:(${WEEKDAY_FULL}|${WEEKDAY_ABBR})\\.?,?\\s+)?` +
+    `(${MONTH_FULL}|${MONTH_ABBR})\\.?\\s+` +
+    '(\\d{1,2})(?:st|nd|rd|th)?' +
+    '(?:,?\\s+(\\d{4}))?',
+  'gi',
+);
+
+/**
+ * Match a time phrase: hour, optional minute, meridiem, abbreviation, and an
+ * optional `(UTC±n)` offset.
+ *
+ * Groups: 1 hour, 2 minute, 3 meridiem, 4 abbreviation, 5 offset sign, 6 offset
+ * magnitude.
+ */
+const TIME_RE =
+  /\b(\d{1,2})(?::(\d{2}))?\s*([AaPp][Mm])\s+([A-Z]{2,5}T)(?:\s*\(UTC([+-])(\d{1,2})\))?/g;
+
+/**
+ * Extract numeric date/time parts for the configured zone from an instant.
+ *
+ * @param {string} timezone - IANA timezone identifier.
+ * @param {Date} instant - Absolute instant to render.
+ * @returns {{year:number,month:number,day:number,hour:number,minute:number,second:number}}
+ */
+function zoneParts(timezone, instant) {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  const out = {};
+  for (const part of dtf.formatToParts(instant)) {
+    if (part.type !== 'literal') {
+      out[part.type] = Number(part.value);
+    }
+  }
+  // Intl renders midnight as hour 24 in some engines; normalize to 0.
+  if (out.hour === 24) out.hour = 0;
+  return out;
+}
+
+/**
+ * Offset in milliseconds (zone-local minus UTC) at a given instant.
+ *
+ * @param {string} timezone - IANA timezone identifier.
+ * @param {Date} instant - Absolute instant.
+ * @returns {number} Offset in milliseconds.
+ */
+function offsetMs(timezone, instant) {
+  const p = zoneParts(timezone, instant);
+  const asUtc = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second);
+  return asUtc - instant.getTime();
+}
+
+/**
+ * Resolve the absolute instant for a wall-clock time in a zone.
+ *
+ * Two refinement passes converge on the correct offset across DST boundaries.
+ *
+ * @param {string} timezone - IANA timezone identifier.
+ * @param {number} year - Four-digit year.
+ * @param {number} month - 1-based month.
+ * @param {number} day - Day of month.
+ * @param {number} [hour=12] - Hour (0-23).
+ * @param {number} [minute=0] - Minute.
+ * @returns {Date} The resolved instant.
+ */
+function instantFromWall(timezone, year, month, day, hour = 12, minute = 0) {
+  const naive = Date.UTC(year, month - 1, day, hour, minute, 0);
+  let ts = naive - offsetMs(timezone, new Date(naive));
+  ts = naive - offsetMs(timezone, new Date(ts));
+  return new Date(ts);
+}
+
+/**
+ * Weekday name for a calendar date in the configured zone.
+ *
+ * @param {string} timezone - IANA timezone identifier.
+ * @param {number} year - Four-digit year.
+ * @param {number} month - 1-based month.
+ * @param {number} day - Day of month.
+ * @returns {string} Full weekday name (e.g. `Saturday`).
+ */
+export function actualWeekday(timezone, year, month, day) {
+  const instant = instantFromWall(timezone, year, month, day, 12, 0);
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    weekday: 'long',
+  }).format(instant);
+}
+
+/**
+ * Timezone abbreviation (e.g. `EST`/`EDT`) for a wall-clock date/time.
+ *
+ * @param {string} timezone - IANA timezone identifier.
+ * @param {number} year - Four-digit year.
+ * @param {number} month - 1-based month.
+ * @param {number} day - Day of month.
+ * @param {number} hour - Hour (0-23).
+ * @param {number} minute - Minute.
+ * @returns {string} Short timezone name.
+ */
+export function dstAbbreviation(timezone, year, month, day, hour, minute) {
+  const instant = instantFromWall(timezone, year, month, day, hour, minute);
+  const part = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    timeZoneName: 'short',
+  })
+    .formatToParts(instant)
+    .find((p) => p.type === 'timeZoneName');
+  return part ? part.value : '';
+}
+
+/**
+ * UTC offset in whole hours for a wall-clock date/time in the zone.
+ *
+ * @param {string} timezone - IANA timezone identifier.
+ * @param {number} year - Four-digit year.
+ * @param {number} month - 1-based month.
+ * @param {number} day - Day of month.
+ * @param {number} hour - Hour (0-23).
+ * @param {number} minute - Minute.
+ * @returns {number} Offset in hours (e.g. -5 for EST).
+ */
+export function zoneOffsetHours(timezone, year, month, day, hour, minute) {
+  const instant = instantFromWall(timezone, year, month, day, hour, minute);
+  return offsetMs(timezone, instant) / 3600000;
+}
+
+/**
+ * Classify a wall-clock time against the zone's DST transitions.
+ *
+ * @param {string} timezone - IANA timezone identifier.
+ * @param {number} year - Four-digit year.
+ * @param {number} month - 1-based month.
+ * @param {number} day - Day of month.
+ * @param {number} hour - Hour (0-23).
+ * @param {number} minute - Minute.
+ * @returns {'gap'|'ambiguous'|null} `gap` for a skipped hour, `ambiguous` for a
+ *   repeated hour, `null` otherwise.
+ */
+export function classifyDstEdge(timezone, year, month, day, hour, minute) {
+  const naive = Date.UTC(year, month - 1, day, hour, minute, 0);
+  const offBefore = offsetMs(timezone, new Date(naive - 6 * 3600000));
+  const offAfter = offsetMs(timezone, new Date(naive + 6 * 3600000));
+  if (offBefore === offAfter) {
+    return null;
+  }
+
+  const wall = [year, month, day, hour, minute].join(',');
+  const renders = (off) => {
+    const p = zoneParts(timezone, new Date(naive - off));
+    return [p.year, p.month, p.day, p.hour, p.minute].join(',');
+  };
+  const matchBefore = renders(offBefore) === wall;
+  const matchAfter = renders(offAfter) === wall;
+
+  if (matchBefore && matchAfter) {
+    return 'ambiguous';
+  }
+  if (!matchBefore && !matchAfter) {
+    return 'gap';
+  }
+  return null;
+}
+
+/**
+ * Convert a 12-hour clock reading to a 24-hour hour value.
+ *
+ * @param {number} hour12 - Hour as written (1-12).
+ * @param {string} meridiem - `AM` or `PM` (any case).
+ * @returns {number} Hour in 0-23.
+ */
+function to24Hour(hour12, meridiem) {
+  const isPm = meridiem.toLowerCase() === 'pm';
+  if (hour12 === 12) {
+    return isPm ? 12 : 0;
+  }
+  return isPm ? hour12 + 12 : hour12;
+}
+
+/**
+ * Validate that a parsed calendar date is real (rejects e.g. Feb 29 non-leap).
+ *
+ * @param {number} year - Four-digit year.
+ * @param {number} month - 1-based month.
+ * @param {number} day - Day of month.
+ * @returns {boolean} True when the date exists.
+ */
+function isValidDate(year, month, day) {
+  const d = new Date(Date.UTC(year, month - 1, day));
+  return (
+    d.getUTCFullYear() === year &&
+    d.getUTCMonth() === month - 1 &&
+    d.getUTCDate() === day
+  );
+}
+
+/**
+ * Preserve the casing convention of an existing token when substituting.
+ *
+ * Abbreviated source (3-letter weekday) yields an abbreviated replacement.
+ *
+ * @param {string} original - Token as written in the source.
+ * @param {string} fullReplacement - Full canonical replacement.
+ * @returns {string} Replacement matching the original's length convention.
+ */
+function matchWeekdayForm(original, fullReplacement) {
+  const stripped = original.replace(/\.$/, '');
+  if (stripped.length <= 3) {
+    return fullReplacement.slice(0, 3);
+  }
+  return fullReplacement;
+}
+
+/**
+ * Build the rule configuration with defaults applied.
+ *
+ * @param {object} raw - Raw config object.
+ * @returns {{timezone:string, defaultYear:number|null}}
+ */
+function resolveConfig(raw) {
+  const timezone =
+    typeof raw.timezone === 'string' && raw.timezone
+      ? raw.timezone
+      : 'America/New_York';
+  const defaultYear =
+    typeof raw.defaultYear === 'number' ? raw.defaultYear : null;
+  return { timezone, defaultYear };
+}
+
+/**
+ * Main rule implementation.
+ *
+ * @param {import("markdownlint").RuleParams} params - Parsed Markdown input.
+ * @param {import("markdownlint").RuleOnError} onError - Violation callback.
+ */
+function dateTimeConsistency(params, onError) {
+  if (!params || !params.lines || typeof onError !== 'function') {
+    return;
+  }
+
+  const rawConfig =
+    params.config?.['date-time-consistency'] || params.config?.DTC001 || {};
+
+  const schema = {
+    timezone: validateString,
+  };
+  const validation = validateConfig(rawConfig, schema, 'date-time-consistency');
+  if (!validation.isValid) {
+    const logger = createMarkdownlintLogger(onError, 'date-time-consistency');
+    logValidationErrors('date-time-consistency', validation.errors, logger);
+  }
+
+  const { timezone, defaultYear } = resolveConfig(rawConfig);
+
+  // Guard against an unusable zone so a typo cannot crash every document.
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezone });
+  } catch {
+    return;
+  }
+
+  const lines = params.lines;
+  const context = buildLineContext(lines);
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNumber = i + 1;
+
+    if (context.isInFencedCode(i) || context.isInFrontmatter(i)) {
+      continue;
+    }
+
+    // Find the last date on the line; time phrases bind to the preceding date.
+    let lastDate = null;
+    DATE_RE.lastIndex = 0;
+    let dateMatch;
+    while ((dateMatch = DATE_RE.exec(line)) !== null) {
+      const matchStart = dateMatch.index;
+      if (context.isInInlineCode(i, matchStart)) {
+        continue;
+      }
+
+      const [, weekdayRaw, monthRaw, dayRaw, yearRaw] = dateMatch;
+      const month = MONTH_INDEX.get(monthRaw.replace(/\.$/, '').toLowerCase());
+      const day = Number(dayRaw);
+      const yearGiven = yearRaw !== undefined;
+      const year = yearGiven
+        ? Number(yearRaw)
+        : (defaultYear ?? new Date().getFullYear());
+
+      if (!month || !isValidDate(year, month, day)) {
+        continue;
+      }
+
+      lastDate = { year, month, day, yearGiven, index: matchStart };
+
+      if (weekdayRaw) {
+        const actual = actualWeekday(timezone, year, month, day);
+        const writtenFull =
+          WEEKDAYS.find(
+            (d) =>
+              d.toLowerCase() ===
+                weekdayRaw.replace(/\.$/, '').toLowerCase() ||
+              d.slice(0, 3).toLowerCase() ===
+                weekdayRaw.replace(/\.$/, '').toLowerCase(),
+          ) || '';
+
+        if (writtenFull && writtenFull !== actual) {
+          const replacement = matchWeekdayForm(weekdayRaw, actual);
+          const yearNote = yearGiven ? '' : ` (assuming year ${year})`;
+          onError({
+            lineNumber,
+            detail:
+              `Weekday does not match the date: ${monthRaw} ${day} ` +
+              `${year} is a ${actual}, not ${weekdayRaw}${yearNote}`,
+            range: [matchStart + 1, weekdayRaw.length],
+            fixInfo: {
+              editColumn: matchStart + 1,
+              deleteCount: weekdayRaw.length,
+              insertText: replacement,
+            },
+          });
+        }
+      }
+    }
+
+    // Time phrases bind to the most recent date at or before their position.
+    TIME_RE.lastIndex = 0;
+    let timeMatch;
+    while ((timeMatch = TIME_RE.exec(line)) !== null) {
+      const matchStart = timeMatch.index;
+      if (context.isInInlineCode(i, matchStart)) {
+        continue;
+      }
+      if (!lastDate || lastDate.index > matchStart) {
+        continue;
+      }
+
+      const [, hourRaw, minRaw, meridiem, abbrRaw, offSign, offMag] = timeMatch;
+      const hour12 = Number(hourRaw);
+      const minute = minRaw ? Number(minRaw) : 0;
+      const hour24 = to24Hour(hour12, meridiem);
+      const { year, month, day } = lastDate;
+
+      const edge = classifyDstEdge(timezone, year, month, day, hour24, minute);
+      if (edge === 'gap') {
+        onError({
+          lineNumber,
+          detail:
+            `Time ${hourRaw}:${String(minute).padStart(2, '0')} ${meridiem} ` +
+            'does not exist on this date (skipped during spring-forward); ' +
+            'verify the intended time manually',
+          range: [matchStart + 1, timeMatch[0].length],
+        });
+        continue;
+      }
+      if (edge === 'ambiguous') {
+        onError({
+          lineNumber,
+          detail:
+            `Time ${hourRaw}:${String(minute).padStart(2, '0')} ${meridiem} ` +
+            'is ambiguous on this date (occurs twice during fall-back); ' +
+            'verify the intended time manually',
+          range: [matchStart + 1, timeMatch[0].length],
+        });
+        continue;
+      }
+
+      // Only validate abbreviations that the zone actually produces.
+      const expectedAbbr = dstAbbreviation(
+        timezone,
+        year,
+        month,
+        day,
+        hour24,
+        minute,
+      );
+      const expectedOffset = zoneOffsetHours(
+        timezone,
+        year,
+        month,
+        day,
+        hour24,
+        minute,
+      );
+
+      // Compute the abbreviation column within the time match.
+      const abbrIndex = timeMatch[0].indexOf(abbrRaw);
+      const abbrColumn = matchStart + abbrIndex + 1;
+
+      const abbrWrong =
+        abbrRaw.toUpperCase() !== expectedAbbr.toUpperCase() &&
+        // Only meaningful when the written abbreviation is one the zone uses.
+        /^E[SD]T$/i.test(abbrRaw);
+
+      const offsetGiven = offSign !== undefined;
+      const writtenOffset = offsetGiven
+        ? Number(`${offSign}${offMag}`)
+        : null;
+      const offsetWrong = offsetGiven && writtenOffset !== expectedOffset;
+
+      if (abbrWrong || offsetWrong) {
+        // Rebuild the canonical abbreviation + offset suffix.
+        const expectedSign = expectedOffset < 0 ? '-' : '+';
+        const canonicalOffset = `(UTC${expectedSign}${Math.abs(expectedOffset)})`;
+        const tail = offsetGiven
+          ? `${expectedAbbr} ${canonicalOffset}`
+          : expectedAbbr;
+        const replaceStart = abbrColumn;
+        const replaceLen = timeMatch[0].length - abbrIndex;
+
+        const detailParts = [];
+        if (abbrWrong) {
+          detailParts.push(`abbreviation should be ${expectedAbbr}, not ${abbrRaw}`);
+        }
+        if (offsetWrong) {
+          detailParts.push(
+            `offset should be UTC${expectedSign}${Math.abs(expectedOffset)}`,
+          );
+        }
+
+        onError({
+          lineNumber,
+          detail: `Timezone ${detailParts.join(' and ')} for this date`,
+          range: [replaceStart, replaceLen],
+          fixInfo: {
+            editColumn: replaceStart,
+            deleteCount: replaceLen,
+            insertText: tail,
+          },
+        });
+      }
+    }
+  }
+}
+
+export default {
+  names: ['date-time-consistency', 'DTC001'],
+  description:
+    'Validates weekdays, timezone abbreviations, and UTC offsets against the calendar date',
+  tags: ['accuracy', 'date'],
+  parser: 'micromark',
+  function: dateTimeConsistency,
+  fixable: true,
+};

--- a/strict-config.jsonc
+++ b/strict-config.jsonc
@@ -17,7 +17,11 @@
     "no-bare-url": true,
     "no-dead-internal-links": true,
     "no-literal-ampersand": true,
-    "no-empty-list-items": true
+    "no-empty-list-items": true,
+    "date-time-consistency": {
+      "timezone": "America/New_York",
+      "defaultYear": null
+    }
   }
 }
 

--- a/tests/integration/esm-compatibility.test.js
+++ b/tests/integration/esm-compatibility.test.js
@@ -33,7 +33,7 @@ describe('Native ESM compatibility', () => {
     
     expect(allRules.default).toBeDefined();
     expect(Array.isArray(allRules.default)).toBe(true);
-    expect(allRules.default.length).toBe(6);
+    expect(allRules.default.length).toBe(7);
     
     // Verify each rule has the expected structure
     allRules.default.forEach(rule => {
@@ -100,7 +100,7 @@ describe('Native ESM compatibility', () => {
     const rules = await import(mainPath);
     expect(rules.default).toBeDefined();
     expect(Array.isArray(rules.default)).toBe(true);
-    expect(rules.default.length).toBe(6);
+    expect(rules.default.length).toBe(7);
   });
 
   test('test_should_work_when_imported_by_rule_name', async () => {
@@ -168,7 +168,7 @@ describe('Backward compatibility', () => {
     // CJS consumers using dynamic import get the module with .default property
     expect(rules.default).toBeDefined();
     expect(Array.isArray(rules.default)).toBe(true);
-    expect(rules.default.length).toBe(6);
+    expect(rules.default.length).toBe(7);
 
     // Document the correct pattern for CJS consumers:
     // const rules = await import('markdownlint-trap');
@@ -190,7 +190,8 @@ describe('Backward compatibility', () => {
       'no-bare-url',
       'no-dead-internal-links',
       'no-literal-ampersand',
-      'no-empty-list-items'
+      'no-empty-list-items',
+      'date-time-consistency'
     ];
     
     const actualRuleNames = allRules.default.flatMap(rule => rule.names);

--- a/tests/unit/date-time-consistency.test.js
+++ b/tests/unit/date-time-consistency.test.js
@@ -1,0 +1,175 @@
+/**
+ * Unit coverage for the date-time-consistency rule (DTC001).
+ *
+ * Exercises the pure date/time helpers and the rule end-to-end through
+ * markdownlint, validating weekday/abbreviation/offset checks, DST edge
+ * detection, code-context skipping, and autofix behavior.
+ */
+import { lint } from 'markdownlint/promise';
+import { applyFixes } from 'markdownlint';
+import dateTimeConsistency from '../../src/rules/date-time-consistency.js';
+import {
+  actualWeekday,
+  dstAbbreviation,
+  zoneOffsetHours,
+  classifyDstEdge,
+} from '../../src/rules/date-time-consistency.js';
+
+const TZ = 'America/New_York';
+
+/**
+ * Lint a markdown string with the rule enabled.
+ *
+ * @param {string} content - Markdown source.
+ * @param {object} [config] - Rule configuration overrides.
+ * @returns {Promise<import('markdownlint').LintError[]>} Errors for the rule.
+ */
+async function run(content, config = {}) {
+  const results = await lint({
+    strings: { doc: content },
+    customRules: [dateTimeConsistency],
+    config: { default: false, 'date-time-consistency': { timezone: TZ, ...config } },
+  });
+  return results.doc;
+}
+
+/**
+ * Apply the rule's autofixes to a markdown string.
+ *
+ * @param {string} content - Markdown source.
+ * @param {object} [config] - Rule configuration overrides.
+ * @returns {Promise<string>} Fixed markdown.
+ */
+async function fix(content, config = {}) {
+  const errors = await run(content, config);
+  return applyFixes(content, errors);
+}
+
+describe('date helpers', () => {
+  it('should compute the actual weekday in the configured zone', () => {
+    expect(actualWeekday(TZ, 2025, 11, 15)).toBe('Saturday');
+    expect(actualWeekday(TZ, 2025, 1, 1)).toBe('Wednesday');
+  });
+
+  it('should report EST for a November date and EDT for a July date', () => {
+    expect(dstAbbreviation(TZ, 2025, 11, 15, 15, 0)).toBe('EST');
+    expect(dstAbbreviation(TZ, 2025, 7, 15, 15, 0)).toBe('EDT');
+  });
+
+  it('should map abbreviations to their UTC offsets via the zone', () => {
+    expect(zoneOffsetHours(TZ, 2025, 11, 15, 15, 0)).toBe(-5);
+    expect(zoneOffsetHours(TZ, 2025, 7, 15, 15, 0)).toBe(-4);
+  });
+
+  it('should flag the spring-forward skipped hour as a gap', () => {
+    expect(classifyDstEdge(TZ, 2025, 3, 9, 2, 30)).toBe('gap');
+  });
+
+  it('should flag the fall-back repeated hour as ambiguous', () => {
+    expect(classifyDstEdge(TZ, 2025, 11, 2, 1, 30)).toBe('ambiguous');
+  });
+
+  it('should report no edge for an ordinary hour', () => {
+    expect(classifyDstEdge(TZ, 2025, 11, 15, 15, 0)).toBe(null);
+  });
+});
+
+describe('weekday validation', () => {
+  it('should flag a wrong weekday and name the actual one', async () => {
+    const errors = await run('Thursday, November 15, 2025 is the date.\n');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].errorDetail).toMatch(/Saturday/);
+  });
+
+  it('should report no findings for correct content', async () => {
+    const errors = await run(
+      'Wednesday, January 1, 2025, at 3:30 PM EST (UTC-5) works.\n',
+    );
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should autofix a wrong weekday to the correct one', async () => {
+    const fixed = await fix('Thursday, November 15, 2025 is the date.\n');
+    expect(fixed).toContain('Saturday, November 15, 2025');
+  });
+});
+
+describe('abbreviation and offset validation', () => {
+  it('should fix EDT to EST and the offset on a November date', async () => {
+    const fixed = await fix(
+      'Saturday, November 15, 2025, at 3:00 PM EDT (UTC-4).\n',
+    );
+    expect(fixed).toContain('3:00 PM EST (UTC-5)');
+  });
+
+  it('should fix a mismatched offset to match the date', async () => {
+    const fixed = await fix(
+      'Saturday, November 15, 2025, at 3:00 PM EDT (UTC-5).\n',
+    );
+    expect(fixed).toContain('3:00 PM EST (UTC-5)');
+  });
+});
+
+describe('DST transition edge hours', () => {
+  it('should flag the skipped hour without offering a fix', async () => {
+    const content = 'Sunday, March 9, 2025, at 2:30 AM EDT.\n';
+    const errors = await run(content);
+    const edge = errors.find((e) => /does not exist|skipped/i.test(e.errorDetail));
+    expect(edge).toBeDefined();
+    expect(edge.fixInfo == null).toBe(true);
+  });
+
+  it('should flag the ambiguous hour without offering a fix', async () => {
+    const content = 'Sunday, November 2, 2025, at 1:30 AM EDT.\n';
+    const errors = await run(content);
+    const edge = errors.find((e) => /ambiguous|occurs twice/i.test(e.errorDetail));
+    expect(edge).toBeDefined();
+    expect(edge.fixInfo == null).toBe(true);
+  });
+});
+
+describe('code context', () => {
+  it('should not flag a date inside a fenced code block', async () => {
+    const content = '```\nThursday, November 15, 2025\n```\n';
+    const errors = await run(content);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should not flag a date inside inline code', async () => {
+    const content = 'See `Thursday, November 15, 2025` in the log.\n';
+    const errors = await run(content);
+    expect(errors).toHaveLength(0);
+  });
+});
+
+describe('default year', () => {
+  it('should assume the current year and note it when the year is omitted', async () => {
+    const year = new Date().getFullYear();
+    const actual = actualWeekday(TZ, year, 11, 15);
+    const wrong = actual === 'Monday' ? 'Tuesday' : 'Monday';
+    const errors = await run(`${wrong}, November 15 is the date.\n`);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].errorDetail).toMatch(new RegExp(String(year)));
+  });
+});
+
+describe('abbreviated and ordinal forms', () => {
+  it('should handle abbreviated month and weekday names', async () => {
+    const errors = await run('Thu, Nov 15, 2025 is the date.\n');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].errorDetail).toMatch(/Sat/);
+  });
+
+  it('should handle ordinal day suffixes', async () => {
+    const errors = await run('Thursday, November 15th, 2025 is the date.\n');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].errorDetail).toMatch(/Saturday/);
+  });
+});
+
+describe('invalid calendar dates', () => {
+  it('should not crash on February 29 in a non-leap year', async () => {
+    const errors = await run('February 29, 2025 is not real.\n');
+    expect(Array.isArray(errors)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the `date-time-consistency` rule (DTC001): validates written weekdays, `EST`/`EDT` abbreviations, and `(UTC±n)` offsets against the numbered calendar date in a configurable IANA timezone.
- Numbered date is authoritative; weekday, abbreviation, and offset mismatches are auto-fixed. DST transition edge hours (skipped on spring-forward, ambiguous on fall-back) are flagged lint-only.
- Zone resolution uses `Intl.DateTimeFormat` with the configured timezone — no runtime timezone-data dependency, works for any IANA zone.
- Wires the rule into `src/index.js`; off by default in the `basic` preset, on in `recommended` and `strict`.
- Documents the rule in the rule catalogue and configuration reference.

Closes #230

## Test plan

### Automated testing
- [x] Unit tests pass (`tests/unit/date-time-consistency.test.js`, 19 cases)
- [x] ESM compatibility export count updated and passing
- [x] Full Jest suite passes (pre-existing flaky perf test and an untracked stray test excluded; both unrelated to this change)

### Manual testing
- [x] Verified weekday/abbreviation/offset checks against known 2025 dates
- [x] Verified DST gap (Mar 9, 2:30 AM) and ambiguous (Nov 2, 1:30 AM) edge detection

### Test coverage
- [x] New rule has unit and end-to-end (via `markdownlint`) coverage
- [x] Tests follow behavioral naming

## Breaking changes

None — new rule, off by default in `basic`. Existing presets gain the rule.

## Documentation

- [x] JSDoc added for exported helpers and the rule entry point
- [x] Rule catalogue and configuration reference updated
