### PR TITLE
Disable Renovate dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -150,10 +150,7 @@
     "platformAutomerge": true,
     "commitMessageAction": "Update"
   },
-  "dependencyDashboard": true,
-  "dependencyDashboardTitle": "Dependency updates dashboard",
-  "dependencyDashboardHeader": "This dashboard tracks all pending dependency updates. PRs are created automatically based on the schedule and grouping rules defined in `.github/renovate.json`.",
-  "dependencyDashboardFooter": "For urgent security updates or to override the schedule, you can manually create PRs from this dashboard.",
+  "dependencyDashboard": false,
   "ignoreDeps": [],
   "ignorePaths": [
     "**/node_modules/**",

--- a/tests/integration/renovate-config.test.js
+++ b/tests/integration/renovate-config.test.js
@@ -205,20 +205,8 @@ describe('Renovate configuration', () => {
   });
 
   describe('dependency dashboard', () => {
-    test('should_enable_dependency_dashboard', () => {
-      expect(config.dependencyDashboard).toBe(true);
-    });
-
-    test('should_have_custom_title', () => {
-      expect(config.dependencyDashboardTitle).toBe(
-        'Dependency updates dashboard'
-      );
-    });
-
-    test('should_have_header_and_footer', () => {
-      expect(config.dependencyDashboardHeader).toBeDefined();
-      expect(config.dependencyDashboardHeader).toContain('.github/renovate.json');
-      expect(config.dependencyDashboardFooter).toBeDefined();
+    test('should_disable_dependency_dashboard', () => {
+      expect(config.dependencyDashboard).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

- Set `dependencyDashboard: false` in `.github/renovate.json` and remove the now-unused title/header/footer keys.
- Update the config test to assert the dashboard is disabled.

Renovate still creates dependency and security PRs on schedule (and dev-dep auto-merge still works) — only the tracking issue (#117) goes away. Renovate will auto-close #117 on its next run.

## Test plan

### Automated testing
- [x] `npm test` — 1717 passed
- [x] Renovate config test passes (45)
- [x] `.github/renovate.json` is valid JSON

## Breaking changes

None — removes an informational tracking issue; dependency/security automation unchanged.

## Documentation

- [x] No public-facing behavior changed