### PR TITLE
Add regression coverage for SC001 first-word edge cases

### DIFF
--- a/tests/features/sentence-case-edge-cases-245.test.js
+++ b/tests/features/sentence-case-edge-cases-245.test.js
@@ -111,3 +111,67 @@ describe('SC001 contextualAllCaps not forced in ordinary prose (issue #245)', ()
     expect(violations.length).toBeGreaterThan(0);
   });
 });
+
+describe('SC001 apostrophe first word (issue #245 reopen)', () => {
+  test('test_should_not_flag_apostrophe_first_word_in_heading', async () => {
+    const violations = await lintMarkdown("## Don't consolidate if it's referenced");
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_apostrophe_first_word_in_bold', async () => {
+    const violations = await lintMarkdown("- **Don't use the delete command**");
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_curly_apostrophe_first_word_in_bold', async () => {
+    const violations = await lintMarkdown('- **Don’t use the delete command**');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_still_flag_lowercase_apostrophe_first_word', async () => {
+    const violations = await lintMarkdown("## don't consolidate the agents");
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0].errorDetail).toMatch(/first word/i);
+  });
+});
+
+describe('SC001 backticked code first word (issue #245 reopen)', () => {
+  test('test_should_not_flag_backticked_code_first_word_in_heading', async () => {
+    const violations = await lintMarkdown('## `.env.example` present and clean');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_backticked_code_first_word_in_bold', async () => {
+    const violations = await lintMarkdown('- **`.env.example` present and clean**');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_backticked_code_first_word_in_numbered_list', async () => {
+    const violations = await lintMarkdown('6. `.env.example` present and clean');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_still_flag_plain_lowercase_first_word_in_heading', async () => {
+    const violations = await lintMarkdown('## converter for code files');
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0].errorDetail).toMatch(/first word/i);
+  });
+});
+
+describe('SC001 bracketed placeholder first word (issue #245 reopen)', () => {
+  test('test_should_not_flag_bracketed_placeholder_first_word_in_heading', async () => {
+    const violations = await lintMarkdown('## [Project Name] task report');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_bracketed_placeholder_first_word_in_bold', async () => {
+    const violations = await lintMarkdown('- **[Project Name] task report**');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_still_flag_plain_lowercase_first_word_without_bracket', async () => {
+    const violations = await lintMarkdown('## converter handles the reports');
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0].errorDetail).toMatch(/first word/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds explicit regression coverage for the three first-word edge cases from the issue #245 reopen (apostrophe, backticked-code, bracketed-placeholder first words)
- Confirms SC001 produces no false positive for these in every context it scans (ATX headings, bold list-item labels) and correctly ignores plain paragraphs / numbered lists
- No production code change required — the cases already pass on `main` after the round-one fix (#254); this fills the missing test coverage the acceptance criteria require

Closes #245

## Background

The reopen reported three remaining false positives. Investigation showed all three already pass on `main`: the leading `[...]` is preserved as a link token, a backticked first token is exempt via the special-character guard, and a capitalized first word (e.g. `Don't`) satisfies the first-word rule. The maintainer's own `edge-cases-245.fixture.md` lints clean. This PR locks that behavior in with 11 tests, each paired with a true-positive guard proving genuine violations still flag.

## Test plan

### Automated testing
- [x] New 245 edge-case suite passes (23 tests)
- [x] Full Jest suite passes (1728 passed, 9 skipped)
- [x] ESLint clean (pre-commit `eslint --fix`)

### Test coverage
- [x] Apostrophe first word: heading, bold, curly-apostrophe bold + lowercase-first-word guard
- [x] Backticked-code first word: heading, bold, numbered list + plain-lowercase-first-word guard
- [x] Bracketed-placeholder first word: heading, bold + plain-lowercase-first-word guard
- [x] Tests follow behavioral naming

## Breaking changes

None — test-only change.

## Documentation

- [x] No public API or behavior change; no docs update needed
