### PR TITLE
Ignore generated dirs in markdownlint config

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -3,6 +3,9 @@
   // Enables all custom rules with balanced strictness
   "ignores": [
     "node_modules/**",
+    ".tmp/**",
+    "tests/.tmp/**",
+    "validation-reports/**",
     "tests/fixtures/**",
     ".claude/**",
     ".windsurf/**",


### PR DESCRIPTION
## Summary

- Add `.tmp/**`, `tests/.tmp/**`, and `validation-reports/**` to the `ignores` list in the markdownlint-cli2 config
- These are gitignored, generated directories (external-validation clones and reports). `npm run lint:md` walked into them: `.tmp/` crashed the run (a cloned repo's config references `markdownlint-trap` as an unresolved module) and `validation-reports/` flooded it with thousands of errors from intentionally non-compliant samples
- CI was unaffected (a fresh checkout has no generated dirs); this fixes the documented `lint:md` command for local use

## Test plan

- [x] `npm run lint:md` no longer crashes; lints 26 tracked files with 0 errors
- [x] Config-only change; no rule or production code touched

## Breaking changes

None.
