### PR TITLE
Stop SC001 flagging the first word when a later contraction is present

### DIFF
--- a/src/rules/shared-heuristics.js
+++ b/src/rules/shared-heuristics.js
@@ -112,7 +112,12 @@ export function preserveSegments(text) {
     segments.push(m);
     return PH + (segments.length - 1) + PE;
   });
-  processed = processed.replace(/'([^']+)'/g, (m) => {
+  // Single-quoted strings only at word boundaries: the opening quote must follow
+  // the start or an opening delimiter, and the closing quote must precede the end
+  // or a closing delimiter. This avoids pairing contraction/possessive apostrophes
+  // (e.g. the ' in "Don't" with the ' in "it's"), which would otherwise preserve
+  // the span between them and mangle the surrounding words (#267).
+  processed = processed.replace(/(?<=^|[\s([{])'([^']+)'(?=$|[\s)\]}.,;:!?])/g, (m) => {
     segments.push(m);
     return PH + (segments.length - 1) + PE;
   });

--- a/src/rules/shared-heuristics.js
+++ b/src/rules/shared-heuristics.js
@@ -116,8 +116,10 @@ export function preserveSegments(text) {
   // the start or an opening delimiter, and the closing quote must precede the end
   // or a closing delimiter. This avoids pairing contraction/possessive apostrophes
   // (e.g. the ' in "Don't" with the ' in "it's"), which would otherwise preserve
-  // the span between them and mangle the surrounding words (#267).
-  processed = processed.replace(/(?<=^|[\s([{])'([^']+)'(?=$|[\s)\]}.,;:!?])/g, (m) => {
+  // the span between them and mangle the surrounding words (#267). The lazy inner
+  // match still allows interior apostrophes, so a genuine quoted phrase that
+  // contains a contraction (e.g. 'I don't know') is preserved as one segment.
+  processed = processed.replace(/(?<=^|[\s([{])'(.+?)'(?=$|[\s)\]}.,;:!?])/g, (m) => {
     segments.push(m);
     return PH + (segments.length - 1) + PE;
   });

--- a/tests/features/sentence-case-contraction-267.test.js
+++ b/tests/features/sentence-case-contraction-267.test.js
@@ -1,0 +1,78 @@
+// @ts-check
+
+/**
+ * Feature tests for SC001 contraction false positive (issue #267).
+ *
+ * A correctly sentence-cased first word such as "Don't" was falsely flagged
+ * as needing capitalization when a *later* word in the same heading or bold
+ * span was also a contraction (e.g. "it's"). The two apostrophes were paired
+ * by the single-quote segment-preservation step, so "Don't ... it's" had its
+ * middle preserved and the first token became a mangled "Don__PRESERVED_0__s".
+ *
+ * The trigger is the later apostrophe word, not the first word: the identical
+ * input without the later contraction is clean. Affects both the ATX-heading
+ * path and the bold-in-list-item path.
+ */
+
+import { describe, test, expect } from '@jest/globals';
+import { lint } from 'markdownlint/promise';
+import sentenceRule from '../../src/rules/sentence-case-heading.js';
+
+/**
+ * Lint markdown content with the SC001 rule and a given config.
+ * @param {string} content Markdown content to lint.
+ * @param {Object} config sentence-case-heading configuration.
+ * @returns {Promise<object[]>} All SC001 violations. The first-word false
+ *   positive is reported without fixInfo, so violations are not filtered on it.
+ */
+async function lintMarkdown(content, config = {}) {
+  const options = {
+    customRules: [sentenceRule],
+    strings: { testContent: content },
+    config: {
+      default: false,
+      'sentence-case-heading': config
+    },
+    resultVersion: 3
+  };
+  const results = await lint(options);
+  return (results.testContent || []).filter(
+    (v) =>
+      v.ruleNames.includes('sentence-case-heading') ||
+      v.ruleNames.includes('SC001')
+  );
+}
+
+describe('SC001 contraction false positive (issue #267)', () => {
+  test('test_should_not_flag_first_contraction_when_later_word_is_contraction_in_heading', async () => {
+    const violations = await lintMarkdown('## Don\'t consolidate if it\'s referenced');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_first_contraction_when_later_word_is_contraction_in_bold', async () => {
+    const violations = await lintMarkdown('- **Don\'t use it\'s thing.**');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_stay_clean_for_single_contraction_heading', async () => {
+    const violations = await lintMarkdown('## Don\'t go there');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_stay_clean_for_heading_without_later_contraction', async () => {
+    const violations = await lintMarkdown('## Don\'t consolidate if it referenced');
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_not_flag_multiple_later_contractions', async () => {
+    const violations = await lintMarkdown("## Don't worry if it's there and we'll fix it");
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_still_preserve_genuine_single_quoted_string', async () => {
+    // A genuinely single-quoted phrase keeps its interior casing preserved, so
+    // the capitalized word inside is not flagged as a lowercase violation.
+    const violations = await lintMarkdown("## Running 'I need Playwright' locally");
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/tests/features/sentence-case-contraction-267.test.js
+++ b/tests/features/sentence-case-contraction-267.test.js
@@ -75,4 +75,22 @@ describe('SC001 contraction false positive (issue #267)', () => {
     const violations = await lintMarkdown("## Running 'I need Playwright' locally");
     expect(violations).toHaveLength(0);
   });
+
+  test('test_should_preserve_single_quoted_phrase_with_interior_contraction', async () => {
+    // A genuine quoted phrase that itself contains a contraction is preserved as
+    // one segment — the boundary-anchored quote pair still wins over the interior
+    // apostrophe, so "I" inside the quote is not flagged.
+    const violations = await lintMarkdown("## Running 'I don't know' locally");
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_stay_clean_for_possessive_plural', async () => {
+    const violations = await lintMarkdown("## The kids' toys are here");
+    expect(violations).toHaveLength(0);
+  });
+
+  test('test_should_stay_clean_for_possessive_then_contraction', async () => {
+    const violations = await lintMarkdown("## Patel's review of it's usage");
+    expect(violations).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

- SC001 falsely reported *"Heading's first word should be capitalized"* on a
  correctly cased first word (e.g. `Don't`) whenever a **later** word in the
  same heading or bold span was also a contraction (e.g. `it's`).
- Root cause: the single-quote branch of `preserveSegments` matched any
  `'...'` pair, so the apostrophe in `Don't` opened a "quoted string" that
  closed at the apostrophe in `it's`. The span between was replaced with a
  `__PRESERVED_0__` placeholder, mangling the first token into
  `Don__PRESERVED_0__s` — which then failed the first-word capitalization check.
- Fix: restrict single-quote preservation to word boundaries — the opening
  quote must follow start-of-text or an opening delimiter, and the closing
  quote must precede end-of-text or a closing delimiter. Contraction and
  possessive apostrophes (surrounded by letters) are no longer paired, while
  genuine single-quoted phrases like `'I need Playwright'` are still preserved.
- The helper is shared, so the fix covers both the ATX-heading path and the
  bold-in-list-item path reported in the issue.

Closes #267

## Test plan

### Automated testing
- [x] New regression tests in `tests/features/sentence-case-contraction-267.test.js`
  (heading path, bold path, multiple later contractions, genuine quoted string,
  and clean-control cases)
- [x] Full Jest suite passes (88 suites, 1688 tests) — no regressions
- [x] ESLint passes

### Test coverage
- [x] New behavior has tests
- [x] Tests follow behavioral naming

## Out of scope

The issue's two secondary observations are intentionally not addressed here, as
the reporter flagged them as separate and lower-confidence:
- Bracket-*prefixed* template headings (`## [Project Name] task report`) — the
  bracket exemption only covers fully-bracketed headings; may be intended.
- BCE001 still flagging `-p` adjacent to bold (`**ZAM**-pəl`), ref #236.

## Breaking changes

None — backward compatible. The single-quote rule is now stricter (more correct),
not looser.

## Documentation

- [ ] No public-facing behavior or API changes; docs unchanged *(optional)*