### PR TITLE
Stop BCE001 flagging -p inside non-ASCII hyphenated words

### DIFF
--- a/src/rules/backtick-code-elements.js
+++ b/src/rules/backtick-code-elements.js
@@ -244,8 +244,10 @@ function backtickCodeElements(params, onError) {
         // pronunciation gloss like "-pəl") forms a false word boundary and the
         // matcher captures only the leading fragment ("-p"). When the character
         // immediately after the match is a letter or combining mark, the match
-        // is part of a longer word, not a code element (#269).
-        if (end < line.length && /\p{L}|\p{M}/u.test(line[end])) {
+        // is part of a longer word, not a code element (#269). Test the
+        // remainder so astral-plane letters (surrogate pairs) are matched as
+        // whole code points, not a lone surrogate half.
+        if (end < line.length && /^[\p{L}\p{M}]/u.test(line.slice(end))) {
           continue;
         }
 

--- a/src/rules/backtick-code-elements.js
+++ b/src/rules/backtick-code-elements.js
@@ -239,6 +239,16 @@ function backtickCodeElements(params, onError) {
           continue;
         }
 
+        // Skip matches truncated mid-word by a non-ASCII letter. The patterns
+        // use ASCII `\w`/`\b`, so a Unicode letter (e.g. the schwa in a
+        // pronunciation gloss like "-pəl") forms a false word boundary and the
+        // matcher captures only the leading fragment ("-p"). When the character
+        // immediately after the match is a letter or combining mark, the match
+        // is part of a longer word, not a code element (#269).
+        if (end < line.length && /\p{L}|\p{M}/u.test(line[end])) {
+          continue;
+        }
+
         // For the path pattern, apply extra heuristics to avoid false positives
         // on natural language like "read/write" or "pass/fail".
         // Only apply this check to patterns that are actually path-matching patterns

--- a/tests/features/backtick-flag-non-ascii-269.test.js
+++ b/tests/features/backtick-flag-non-ascii-269.test.js
@@ -1,0 +1,62 @@
+/**
+ * @feature
+ * Tests for BCE001 truncating hyphenated words at non-ASCII letters (#269).
+ *
+ * The CLI-flag pattern (and other ASCII-only patterns) use `\w`/`\b`, which do
+ * not treat non-ASCII letters as word characters. A hyphenated word whose
+ * continuation contains a non-ASCII letter (e.g. the schwa in a pronunciation
+ * gloss like "-pəl") produces a false word boundary, so the matcher captures
+ * only the leading "-p" fragment and reports it as a command flag. Genuine bare
+ * flags like "-p" must still be flagged.
+ */
+import { describe, test, expect } from "@jest/globals";
+import { lint } from "markdownlint/promise";
+import backtickRule from "../../src/rules/backtick-code-elements.js";
+
+/**
+ * @param {string} markdown
+ * @returns {Promise<Array>}
+ */
+async function getBCE001Violations(markdown) {
+  const options = {
+    customRules: [backtickRule],
+    strings: { "test.md": markdown },
+    resultVersion: 3,
+  };
+  const results = await lint(options);
+  const violations = results["test.md"] || [];
+  return violations.filter(
+    (v) =>
+      v.ruleNames.includes("backtick-code-elements") ||
+      v.ruleNames.includes("BCE001"),
+  );
+}
+
+describe("BCE001 non-ASCII hyphenated words (#269)", () => {
+  test("does not flag -p inside a schwa pronunciation gloss", async () => {
+    const violations = await getBCE001Violations("Plain -pəl without bold.");
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag -p inside a gloss adjacent to bold", async () => {
+    const violations = await getBCE001Violations(
+      "The pronunciation **ZAM**-pəl is a gloss.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag -p inside a diaeresis-suffixed word", async () => {
+    const violations = await getBCE001Violations("Plain -pël without bold.");
+    expect(violations).toHaveLength(0);
+  });
+
+  test("still flags a genuine bare flag", async () => {
+    const violations = await getBCE001Violations("Run -p now.");
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  test("still flags a genuine long flag", async () => {
+    const violations = await getBCE001Violations("Pass --verbose to the command.");
+    expect(violations.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/features/backtick-flag-non-ascii-269.test.js
+++ b/tests/features/backtick-flag-non-ascii-269.test.js
@@ -50,6 +50,12 @@ describe("BCE001 non-ASCII hyphenated words (#269)", () => {
     expect(violations).toHaveLength(0);
   });
 
+  test("does not flag -p truncated by an astral-plane letter", async () => {
+    // -p followed by MATHEMATICAL BOLD SMALL A (U+1D41A), a surrogate pair.
+    const violations = await getBCE001Violations("Plain -p\u{1D41A}l without bold.");
+    expect(violations).toHaveLength(0);
+  });
+
   test("still flags a genuine bare flag", async () => {
     const violations = await getBCE001Violations("Run -p now.");
     expect(violations.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

- BCE001 reported `-p` as a command flag when it appeared at the start of a
  hyphenated word whose continuation contained a non-ASCII letter — e.g. a
  pronunciation gloss like `-pəl` (schwa, U+0259).
- Root cause: the rule's detection patterns use ASCII `\w`/`\b`. A non-ASCII
  letter forms a false word boundary, so the CLI-flag matcher captured only the
  leading `-p` fragment from the middle of a word. The bold adjacency reported
  in the issue was incidental — the false positive fires with no bold present.
- Fix: in the match-dispatch loop, skip a match when the character immediately
  after it is a Unicode letter or combining mark (`\p{L}`/`\p{M}`). For ASCII
  patterns this can only happen when the regex truncated a longer word, so the
  match is prose, not a code element. The guard is general — it covers every
  pattern, not just CLI flags.

Closes #269

## Test plan

### Automated testing
- [x] New regression tests in `tests/features/backtick-flag-non-ascii-269.test.js`
  (schwa gloss, bold-adjacent gloss, diaeresis suffix, genuine `-p`, genuine `--verbose`)
- [x] Full Jest suite passes (89 suites, 1696 tests) — no regressions
- [x] ESLint passes

### Test coverage
- [x] New behavior has tests
- [x] Genuine bare and long flags still flag (no recall loss)

## Breaking changes

None — strictly removes false positives; genuine flags are unaffected.

## Documentation

- [ ] No public-facing behavior or API changes; docs unchanged *(optional)*