### PR TITLE
Pin bootstrap template to a portable GitHub dependency

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -9,6 +9,7 @@ Hardened local distribution against JSONC corruption and pnpm projects (#280).
 - Rewrote `mergeJsonSettings` on `jsonc.modify`/`applyEdits` — the line-splice approach never added a trailing comma to the template's last property, so any project with a key after the `markdownlint.config` block received invalid JSON
 - Routed pnpm projects to `pnpm install`; `npm install` aborts on a pnpm workspace
 - Exported `mergeJsonSettings`/`usesPnpm` so the merge and install-routing logic carry direct unit coverage instead of subprocess-only tests
+- Switched the bootstrap `templates/package.json` dependency from `file:../markdownlint-styleguide` to the `github:` tag — a relative `file:` path only resolves where the consumer is a sibling of this repo, breaking CI and fresh clones (#282)
 
 ---
 

--- a/templates/package.json
+++ b/templates/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "markdownlint-cli2": "^0.22.1",
-    "markdownlint-styleguide": "file:../markdownlint-styleguide"
+    "markdownlint-styleguide": "github:kynoptic/markdownlint-styleguide#v4.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Change the bootstrap `templates/package.json` styleguide dependency from `file:../markdownlint-styleguide` to `github:kynoptic/markdownlint-styleguide#v4.0.0`.
- A relative `file:` path only resolves where the bootstrapped project is a sibling of this repo, so any clone elsewhere (CI runner, fresh machine, collaborator) fails `npm install`. The GitHub tag resolves anywhere and pins a reproducible version.

Closes #282

## Test plan

### Automated testing
- [x] Full Jest suite passes (no test asserts the template dependency form)
- [x] CI green

## Breaking changes

None — affects only newly bootstrapped projects.

## Documentation

- [x] DEVLOG updated (engineering-only change)