### PR TITLE
Batch Renovate dependency updates

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -10,6 +10,7 @@ Hardened local distribution against JSONC corruption and pnpm projects (#280).
 - Routed pnpm projects to `pnpm install`; `npm install` aborts on a pnpm workspace
 - Exported `mergeJsonSettings`/`usesPnpm` so the merge and install-routing logic carry direct unit coverage instead of subprocess-only tests
 - Switched the bootstrap `templates/package.json` dependency from `file:../markdownlint-styleguide` to the `github:` tag — a relative `file:` path only resolves where the consumer is a sibling of this repo, breaking CI and fresh clones (#282)
+- Updated dev tooling — `eslint`, `jest`, `globals`, `markdown-it` — and `js-yaml`; batched the five open Renovate updates into one tested commit instead of five conflicting lockfile merges (#273-#277)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "markdownlint-styleguide",
       "version": "4.0.0",
       "dependencies": {
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.2.0",
         "jsonc-parser": "^3.3.1"
       },
       "bin": {
@@ -18,13 +18,13 @@
         "@eslint/js": "^10.0.1",
         "@types/jest": "^30.0.0",
         "debug": "^4.4.3",
-        "eslint": "^10.1.0",
+        "eslint": "^10.4.1",
         "glob": "^11.1.0",
-        "globals": "^17.4.0",
+        "globals": "^17.6.0",
         "husky": "^9.1.7",
-        "jest": "^30.3.0",
+        "jest": "^30.4.2",
         "lint-staged": "^16.4.0",
-        "markdown-it": "^14.1.1",
+        "markdown-it": "^14.2.0",
         "markdownlint": "^0.40.0",
         "markdownlint-cli2": "^0.22.1",
         "prettier": "^3.8.3"
@@ -2700,9 +2700,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
-      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
+      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2711,7 +2711,7 @@
         "@eslint/config-array": "^0.23.5",
         "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -4456,7 +4456,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4588,8 +4600,20 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -4838,13 +4862,25 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -4911,6 +4947,37 @@
       },
       "peerDependencies": {
         "markdownlint-cli2": ">=0.0.4"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/markdownlint/node_modules/string-width": {
@@ -6503,6 +6570,8 @@
     },
     "node_modules/uc.micro": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\""
   },
   "dependencies": {
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.2.0",
     "jsonc-parser": "^3.3.1"
   },
   "peerDependencies": {
@@ -80,13 +80,13 @@
     "@eslint/js": "^10.0.1",
     "@types/jest": "^30.0.0",
     "debug": "^4.4.3",
-    "eslint": "^10.1.0",
+    "eslint": "^10.4.1",
     "glob": "^11.1.0",
-    "globals": "^17.4.0",
+    "globals": "^17.6.0",
     "husky": "^9.1.7",
-    "jest": "^30.3.0",
+    "jest": "^30.4.2",
     "lint-staged": "^16.4.0",
-    "markdown-it": "^14.1.1",
+    "markdown-it": "^14.2.0",
     "markdownlint": "^0.40.0",
     "markdownlint-cli2": "^0.22.1",
     "prettier": "^3.8.3"


### PR DESCRIPTION
## Summary

- Apply the five open Renovate dependency updates in one consistent, tested commit: `eslint` ^10.4.1, `jest` ^30.4.2, `globals` ^17.6.0, `markdown-it` ^14.2.0, `js-yaml` ^4.2.0.
- Batching avoids five sequential merges that would each conflict in the shared `devDependencies` block of `package.json`/`package-lock.json`.
- Supersedes #273, #274, #275, #276, #277 — Renovate closes those once their target versions land on `main`.

## Test plan

### Automated testing
- [x] `npm test` — full Jest suite passes (86 suites, 1672 tests)
- [x] `npm run lint` — ESLint clean
- [x] CI green

## Breaking changes

None — minor/patch updates to dev tooling and js-yaml.

## Documentation

- [x] DEVLOG updated (engineering-only change)