### PR TITLE
Align recommended preset configs and exempt project-title files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,7 @@ Presets differ in custom rule coverage and standard rule relaxations:
 | `MD041` first-line-h1 | off | off | **on** |
 | `MD024` duplicate heading | on | off | on |
 | `MD036` emphasis as heading | on | off | on |
+| `MD060` table-column-style | `any` | **`compact`** | `any` |
 
 - **Basic** (`basic-config.jsonc`) — high-signal custom rules only
 - **Recommended** (`recommended-config.jsonc`) — all custom rules, pragmatic relaxations for real-world docs

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -187,7 +187,17 @@ markdownlint-styleguide uses a three-tier confidence system to determine autofix
 
 ### Safe and unsafe words
 
-`safeWords` boosts confidence; `unsafeWords` penalizes:
+Both lists nudge the autofix confidence score that picks a fix's tier:
+boosting pushes a fix toward auto-apply, penalizing demotes it toward review.
+Each matches a flagged token by exact, case-insensitive string (not substring),
+and a word may not appear in both lists.
+
+- `safeWords` (+0.3): the term is unambiguously code, so apply the fix
+  automatically — e.g. tool names like `webpack`.
+- `unsafeWords` (-0.5): the term is a homograph that is often ordinary prose
+  (`spring`, `rust`, `swift`), so route the fix to needs-review instead of
+  guessing. This tilts toward caution; it does not veto the fix. To suppress or
+  always-review a term outright, use `neverFlag` or `alwaysReview` below.
 
 ```jsonc
 {

--- a/recommended-config.jsonc
+++ b/recommended-config.jsonc
@@ -14,6 +14,7 @@
     "MD029": { "style": "one" },
     "MD004": { "style": "dash" },
     "MD036": false, // no-emphasis-as-heading
+    "MD060": { "style": "compact" }, // table-column-style
 
     // Enable custom rules from this package
     "sentence-case-heading": {

--- a/recommended-markdownlint.jsonc
+++ b/recommended-markdownlint.jsonc
@@ -9,6 +9,7 @@
   "MD029": { "style": "one" },
   "MD004": { "style": "dash" },
   "MD036": false, // no-emphasis-as-heading
+  "MD060": { "style": "compact" }, // table-column-style
 
   // Custom rules from markdownlint-styleguide
   "sentence-case-heading": {

--- a/recommended-markdownlint.jsonc
+++ b/recommended-markdownlint.jsonc
@@ -42,5 +42,12 @@
   "no-bare-url": true,
   "no-dead-internal-links": true,
   "no-literal-ampersand": true,
-  "no-empty-list-items": true
+  "no-empty-list-items": true,
+  "date-time-consistency": {
+    // Numbered dates are authoritative; weekdays, EST/EDT, and UTC offsets
+    // are validated and fixed against this IANA zone. Override `timezone` in
+    // the extending repo's own config to validate against a different zone.
+    "timezone": "America/New_York",
+    "defaultYear": null
+  }
 }

--- a/src/rules/sentence-case-heading.js
+++ b/src/rules/sentence-case-heading.js
@@ -285,8 +285,10 @@ function basicSentenceCaseHeadingFunction(params, onError) {
     if (token.type === 'atxHeading') {
       const lineNumber = token.startLine;
       // The first H1 of a conventional project-root file is the project
-      // title (often an all-acronym name), not prose — exempt it.
-      if (lineNumber === 1 && /(?:README|AGENTS|CLAUDE)\.md$/i.test(params.name || '')) {
+      // title (often an all-acronym name), not prose — exempt it. Anchor to a
+      // path boundary so only the basename matches (not e.g. `MY-README.md`);
+      // case-insensitive to allow conventional lowercase variants.
+      if (lineNumber === 1 && /(?:^|[/\\])(?:README|AGENTS|CLAUDE)\.md$/i.test(params.name || '')) {
         return;
       }
       const sourceLine = lines[lineNumber - 1];

--- a/src/rules/sentence-case-heading.js
+++ b/src/rules/sentence-case-heading.js
@@ -284,7 +284,9 @@ function basicSentenceCaseHeadingFunction(params, onError) {
   tokens.forEach((token) => {
     if (token.type === 'atxHeading') {
       const lineNumber = token.startLine;
-      if (lineNumber === 1 && /README\.md$/i.test(params.name || '')) {
+      // The first H1 of a conventional project-root file is the project
+      // title (often an all-acronym name), not prose — exempt it.
+      if (lineNumber === 1 && /(?:README|AGENTS|CLAUDE)\.md$/i.test(params.name || '')) {
         return;
       }
       const sourceLine = lines[lineNumber - 1];

--- a/tests/features/sentence-case-project-title.test.js
+++ b/tests/features/sentence-case-project-title.test.js
@@ -53,6 +53,16 @@ describe('sentence-case project-title exemption', () => {
     expect(errors).toHaveLength(1);
   });
 
+  // The exemption matches the basename only — a name that merely *ends* with an
+  // exempt token (no path boundary) is a different file and must still validate.
+  test.each(['MYREADME.md', 'foo-CLAUDE.md', 'PREAGENTS.md'])(
+    'should_flag_line_1_title_when_file_only_suffix_matches_%s',
+    async (name) => {
+      const errors = await lintNamed(name, '# HMS IT\n');
+      expect(errors).toHaveLength(1);
+    },
+  );
+
   test('should_only_exempt_line_1_and_still_validate_later_headings', async () => {
     const content = '# HMS IT\n\n## Heading In Title Case\n';
     const errors = await lintNamed('AGENTS.md', content);

--- a/tests/features/sentence-case-project-title.test.js
+++ b/tests/features/sentence-case-project-title.test.js
@@ -1,0 +1,62 @@
+// @ts-check
+
+/**
+ * Test suite for the project-title exemption in the sentence-case rule.
+ * The first H1 of a conventional project-root file (README.md, AGENTS.md,
+ * CLAUDE.md) is the project name — often an all-acronym title — and is exempt
+ * from sentence-case validation. The exemption is scoped to line 1 only.
+ */
+
+import { describe, test, expect } from '@jest/globals';
+import { lint } from 'markdownlint/promise';
+import sentenceCaseRule from '../../src/rules/sentence-case-heading.js';
+
+/**
+ * Lint a single named document with only the sentence-case rule enabled.
+ * @param {string} name - Filename used as the markdownlint source name.
+ * @param {string} content - Markdown content to lint.
+ * @returns {Promise<object[]>} Array of lint violations.
+ */
+async function lintNamed(name, content) {
+  const result = await lint({
+    strings: { [name]: content },
+    config: {
+      default: false,
+      'sentence-case-heading': true,
+    },
+    customRules: [sentenceCaseRule],
+  });
+  return result[name] || [];
+}
+
+describe('sentence-case project-title exemption', () => {
+  const projectFiles = ['README.md', 'AGENTS.md', 'CLAUDE.md'];
+
+  test.each(projectFiles)(
+    'should_exempt_line_1_all_caps_title_when_file_is_%s',
+    async (name) => {
+      const errors = await lintNamed(name, '# HMS IT\n');
+      expect(errors).toHaveLength(0);
+    },
+  );
+
+  test.each(projectFiles)(
+    'should_exempt_line_1_title_when_file_is_%s_in_a_subdirectory',
+    async (name) => {
+      const errors = await lintNamed(`docs/${name}`, '# HMS IT\n');
+      expect(errors).toHaveLength(0);
+    },
+  );
+
+  test('should_flag_line_1_all_caps_title_when_file_is_not_a_project_title', async () => {
+    const errors = await lintNamed('CONTRIBUTING.md', '# HMS IT\n');
+    expect(errors).toHaveLength(1);
+  });
+
+  test('should_only_exempt_line_1_and_still_validate_later_headings', async () => {
+    const content = '# HMS IT\n\n## Heading In Title Case\n';
+    const errors = await lintNamed('AGENTS.md', content);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].lineNumber).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- Make the flat `recommended-markdownlint.jsonc` genuinely equivalent to the nested `recommended-config.jsonc` it claims to mirror — the flat file was missing the `date-time-consistency` rule block, so `config.extends` consumers silently lost that rule
- Set an explicit `MD060` (`table-column-style`) of `compact` in both recommended configs so consumers get predictable table linting instead of the finicky default `style: "any"` and its confusing closest-match errors
- Extend the `sentence-case-heading` line-1 H1 exemption from `README.md` only to also cover `AGENTS.md` and `CLAUDE.md`, whose H1 is the project name (often an all-acronym title that tripped the all-caps check)
- Document the recommended `MD060` choice and clarify the `safeWords`/`unsafeWords` confidence mechanics in the configuration doc

## Test plan

### Automated testing
- [x] Full Jest suite passes (1671 passed; 1 pre-existing unrelated skip)
- [x] New `tests/features/sentence-case-project-title.test.js` covers README/AGENTS/CLAUDE line-1 exemption, subdirectory paths, a non-title control file that still flags, and line-1-only scoping
- [x] ESLint clean
- [x] `markdownlint-cli2` clean

### Test coverage
- [x] New exemption behavior has tests with behavioral naming
- [x] Config equivalence verified via normalized JSON comparison

## Breaking changes

None — additive config changes and a broadened exemption; backward compatible for existing consumers.

## Documentation

- [x] `docs/configuration.md` updated: `MD060` preset row and expanded safe/unsafe words explanation