### PR TITLE
Stop BCE001 from corrupting @-import paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ User-facing changes — new capabilities, behavior changes, fixes that affected 
 
 ---
 
+## [4.0.2] - 2026-06-05
+
+Stop BCE001 from corrupting paths that begin with `@`.
+
+### Fixed
+
+- BCE001 no longer wraps the path that follows an `@` in backticks. Previously a
+  Claude Code include such as `@docs/foo.md` was autofixed to `` @`docs/foo.md` ``,
+  which broke the file-inclusion mechanism that `AGENTS.md` and `CLAUDE.md` rely
+  on. The guard also covers scoped npm packages (`@scope/pkg`) and email local
+  parts. (#286)
+
+---
+
 ## [4.0.1] - 2026-06-05
 
 Align recommended presets and broaden the project-title heading exemption.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-styleguide",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "keywords": [
     "markdownlint",
     "markdownlint-rule",

--- a/src/rules/backtick-code-elements.js
+++ b/src/rules/backtick-code-elements.js
@@ -225,6 +225,21 @@ function backtickCodeElements(params, onError) {
           continue;
         }
 
+        // Skip matches that are part of a Claude Code @-import (@docs/foo.md),
+        // a scoped npm package (@scope/pkg), or an email local part. Walk back
+        // over path-ish characters; if that run begins right after '@', the
+        // match sits inside an @-token. The '@' is outside the matched range,
+        // so inserting a backtick (@`docs/foo.md`) splits the token and breaks
+        // the import — and a later pattern can re-match a trailing segment
+        // (foo.md) preceded by '/', so a simple start-1 check is not enough. (#286)
+        let atScan = start - 1;
+        while (atScan >= 0 && /[\w.\-/]/.test(line[atScan])) {
+          atScan--;
+        }
+        if (atScan >= 0 && line[atScan] === '@') {
+          continue;
+        }
+
         // Skip matches that begin mid-word because an apostrophe (or other
         // non-word character the regex cannot cross) split an ordinary token.
         // For prose like "stop/don't/wait/wrong/undo/actually" the path pattern

--- a/tests/features/backtick-at-import-paths.test.js
+++ b/tests/features/backtick-at-import-paths.test.js
@@ -1,0 +1,92 @@
+/**
+ * @feature
+ * Tests for BCE001 handling of `@`-prefixed import paths (#286).
+ *
+ * Claude Code `@`-imports (e.g. `@docs/folder-structure.md`) pull other files
+ * into AGENTS.md / CLAUDE.md context. The path after `@` must stay bare — a
+ * backtick inserted after the `@` (`` @`docs/foo.md` ``) breaks the import.
+ * The same guard covers scoped npm packages (`@scope/pkg`) and email local
+ * parts, none of which should be split by an inserted backtick.
+ */
+import { describe, test, expect } from "@jest/globals";
+import { lint } from "markdownlint/promise";
+import { applyFixes } from "markdownlint";
+import backtickRule from "../../src/rules/backtick-code-elements.js";
+
+/**
+ * @param {string} markdown
+ * @returns {Promise<Array>}
+ */
+async function getBCE001Violations(markdown) {
+  const options = {
+    customRules: [backtickRule],
+    strings: { "test.md": markdown },
+    resultVersion: 3,
+  };
+  const results = await lint(options);
+  const violations = results["test.md"] || [];
+  return violations.filter(
+    (v) =>
+      v.ruleNames.includes("backtick-code-elements") ||
+      v.ruleNames.includes("BCE001"),
+  );
+}
+
+/**
+ * Lint then apply BCE001 autofixes, returning the resulting text.
+ * @param {string} markdown
+ * @returns {Promise<string>}
+ */
+async function fixBCE001(markdown) {
+  const results = await lint({
+    customRules: [backtickRule],
+    config: { default: false }, // isolate BCE001 from MD047 trailing-newline etc.
+    strings: { "test.md": markdown },
+    resultVersion: 3,
+  });
+  return applyFixes(markdown, results["test.md"] || []);
+}
+
+describe("BCE001 @-prefixed import paths (#286)", () => {
+  test("does not flag @-import path in prose", async () => {
+    const violations = await getBCE001Violations(
+      "See @docs/folder-structure.md for the full hierarchy.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag @-import path in a table cell", async () => {
+    const violations = await getBCE001Violations(
+      "| Where content belongs and why | @docs/locations.md |",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag nested @-import path", async () => {
+    const violations = await getBCE001Violations(
+      "Patterns live in @docs/design/agent-tools.md and elsewhere.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag scoped npm package after @", async () => {
+    const violations = await getBCE001Violations(
+      "Install @adeze/raindrop-mcp as a fallback.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("autofix leaves @-import paths byte-identical", async () => {
+    const input =
+      "See @docs/folder-structure.md and @docs/para-principles.md for rules.";
+    const fixed = await fixBCE001(input);
+    expect(fixed).toBe(input);
+  });
+
+  test("still flags a bare path NOT preceded by @", async () => {
+    const violations = await getBCE001Violations(
+      "Edit docs/folder-structure.md to update the hierarchy.",
+    );
+    expect(violations.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- BCE001 flagged the path portion of a Claude Code `@`-import (e.g. `@docs/foo.md`) as an un-backticked file path. Because the `@` sits outside the matched range, `--fix` inserted a backtick right after it, producing `` @`docs/foo.md` `` and breaking the file-inclusion mechanism `AGENTS.md` / `CLAUDE.md` rely on.
- Fix walks back over path characters from each match; if the run begins right after an `@`, the match is part of an `@`-token and is skipped. This also covers nested trailing segments (a later pattern re-matching `foo.md`), scoped npm packages (`@scope/pkg`), and email local parts.
- Bumped to 4.0.1.

Closes #286

## Test plan

### Automated testing
- [x] New regression suite `tests/features/backtick-at-import-paths.test.js` (prose, table cell, nested path, scoped package, autofix byte-stability, and a control that still flags a bare path).
- [x] Full suite green: 87 suites / 1678 tests, no regressions.
- [x] `npm run lint:md` clean; `eslint` clean.

### Manual testing
- [x] `applyFixes` over `@docs/...` imports leaves the paths unchanged.

## Breaking changes

None — narrows BCE001 to stop a false positive.

## Documentation

- [x] CHANGELOG updated.