### PR TITLE
Add Apple and Microsoft brand casing to sentence-case dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ User-facing changes — new capabilities, behavior changes, fixes that affected 
 
 ---
 
+## [4.0.3] - 2026-06-05
+
+Teach the sentence-case dictionary the Apple and Microsoft brand names.
+
+### Fixed
+
+- SC001 keeps the canonical casing of `iCloud`, `iPhone`, `iPad`, `iMac`, `iPod`,
+  `iTunes`, `iMovie`, `iWork`, `iPadOS`, `watchOS`, `tvOS`, `MacBook`,
+  `MacBook Air`, `MacBook Pro`, `Apple Photos`, `Apple Music`, and `OneDrive` in
+  headings and bold text. Previously a heading like `## iCloud sync` was
+  autofixed to `Icloud sync`. Terms that collide with common English (such as
+  "Time Machine") stay in per-repo `properNouns` config by design. (#288)
+
+---
+
 ## [4.0.2] - 2026-06-05
 
 Stop BCE001 from corrupting paths that begin with `@`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-styleguide",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "keywords": [
     "markdownlint",
     "markdownlint-rule",

--- a/src/rules/shared-constants.js
+++ b/src/rules/shared-constants.js
@@ -201,6 +201,24 @@ export const casingTerms = {
   apache: 'Apache',
   apple: 'Apple',
   'apple mail': 'Apple Mail',
+  'apple music': 'Apple Music',
+  'apple photos': 'Apple Photos',
+  // Apple devices and operating systems (internal-caps brand names).
+  // ios/macos live with the other OS acronyms below.
+  icloud: 'iCloud',
+  imac: 'iMac',
+  imovie: 'iMovie',
+  ipad: 'iPad',
+  ipados: 'iPadOS',
+  iphone: 'iPhone',
+  ipod: 'iPod',
+  itunes: 'iTunes',
+  iwork: 'iWork',
+  macbook: 'MacBook',
+  'macbook air': 'MacBook Air',
+  'macbook pro': 'MacBook Pro',
+  tvos: 'tvOS',
+  watchos: 'watchOS',
   argocd: 'ArgoCD',
   atlassian: 'Atlassian',
   auth0: 'Auth0',
@@ -221,6 +239,7 @@ export const casingTerms = {
   opencode: 'OpenCode',
   sharepoint: 'SharePoint',  // Microsoft SharePoint (camelCase brand name)
   powerpoint: 'PowerPoint',
+  onedrive: 'OneDrive',  // Microsoft OneDrive (camelCase brand name)
   cloudflare: 'Cloudflare',
   codeberg: 'Codeberg',
   confluence: 'Confluence',

--- a/tests/features/sentence-case-apple-microsoft-brands.test.js
+++ b/tests/features/sentence-case-apple-microsoft-brands.test.js
@@ -1,0 +1,68 @@
+// @ts-check
+
+/**
+ * @feature
+ * SC001 must preserve universal Apple/Microsoft brand casing in headings and
+ * bold text (#288). `ios`/`macos`/`github` were already in the default casing
+ * dictionary, but the Apple device/product family, `MacBook`, `Apple Photos`,
+ * `Apple Music`, and `OneDrive` were missing, so headings like `## iCloud
+ * Storage` were autofixed to `Icloud storage`.
+ *
+ * Scope is unambiguous universal brands only. Terms that collide with common
+ * English (e.g. "Time Machine") stay in per-repo properNouns config.
+ */
+import { describe, test, expect } from '@jest/globals';
+import { lint } from 'markdownlint/promise';
+import sentenceRule from '../../src/rules/sentence-case-heading.js';
+
+/**
+ * @param {string} content
+ * @returns {Promise<object[]>}
+ */
+async function getSC001Violations(content) {
+  const results = await lint({
+    customRules: [sentenceRule],
+    strings: { 'test.md': content },
+    config: { default: false, 'sentence-case-heading': {} },
+    resultVersion: 3,
+  });
+  return (results['test.md'] || []).filter(
+    (v) =>
+      v.ruleNames.includes('sentence-case-heading') ||
+      v.ruleNames.includes('SC001'),
+  );
+}
+
+const brandHeadings = [
+  '## iCloud sync',
+  '## iPhone setup',
+  '## iPad configuration',
+  '## iMac teardown',
+  '## iPod nano',
+  '## iTunes library',
+  '## iMovie export',
+  '## iWork suite',
+  '## iPadOS release notes',
+  '## watchOS faces',
+  '## tvOS remote',
+  '## MacBook backup',
+  '## MacBook Air backup',
+  '## MacBook Pro setup',
+  '## Apple Photos sync',
+  '## Apple Music ratings',
+  '## OneDrive migration',
+];
+
+describe('SC001 preserves Apple/Microsoft brand casing (#288)', () => {
+  for (const heading of brandHeadings) {
+    test(`does not flag "${heading}"`, async () => {
+      const violations = await getSC001Violations(heading);
+      expect(violations).toHaveLength(0);
+    });
+  }
+
+  test('still flags a genuine title-case heading', async () => {
+    const violations = await getSC001Violations('## Audit Protocol');
+    expect(violations.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/features/sentence-case-identifiers.test.js
+++ b/tests/features/sentence-case-identifiers.test.js
@@ -151,17 +151,18 @@ describe("sentence-case-heading identifier preservation", () => {
   });
 
   describe("should NOT preserve brand names as code identifiers", () => {
-    test("iPhone is flagged unless in specialCasedTerms (not treated as code)", async () => {
-      // iPhone is a brand name, not a code identifier
-      // It should be flagged by sentence-case unless added to specialCasedTerms
+    test("eBay is flagged unless in properNouns (not treated as code)", async () => {
+      // eBay is a camelCase brand name, not a code identifier
+      // It should be flagged by sentence-case unless added to properNouns
       // This verifies the code identifier exemption doesn't wrongly exempt brands
+      // (iPhone et al. are now first-class entries in casingTerms by design)
       const violations = await lintString(
-        "## Using your iPhone\n",
+        "## Using your eBay\n",
       );
-      // iPhone is NOT in default casingTerms, so it gets flagged
-      // Users should add it to specialCasedTerms if they want to preserve it
+      // eBay is NOT in default casingTerms, so it gets flagged
+      // Users should add it to properNouns if they want to preserve it
       expect(violations.length).toBe(1);
-      expect(violations[0].errorDetail).toContain("iPhone");
+      expect(violations[0].errorDetail).toContain("eBay");
     });
 
     test("McDonald is flagged unless in specialCasedTerms (not treated as code)", async () => {


### PR DESCRIPTION
## Summary

- SC001's default casing dictionary (`casingTerms`) had `ios`/`macos`/`github` but was missing the Apple device/product family, `MacBook` variants, `Apple Photos`, `Apple Music`, and `OneDrive`. Headings like `## iCloud sync` were autofixed to `Icloud sync`.
- Adds those brands so their canonical casing is preserved in headings and bold text.
- Terms that collide with common English (e.g. "Time Machine") are deliberately left to per-repo `properNouns` config, not the global default.

Closes #288

## Test plan

### Automated testing
- [x] New suite `sentence-case-apple-microsoft-brands.test.js` covers all added brands plus a control that still flags a genuine title-case heading (`Audit Protocol`).
- [x] Updated `sentence-case-identifiers.test.js` to use `eBay` (a camelCase brand still absent from the dictionary) since `iPhone` is now a first-class entry.
- [x] Full suite green: 89 suites / 1707 tests.
- [x] `eslint` and `npm run lint:md` clean.

## Breaking changes

None — broadens recognized casing; existing detection unaffected.

## Documentation

- [x] CHANGELOG updated (4.0.3).