### PR TITLE
Preserve acronym and proper-noun casing inside punctuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ User-facing changes — new capabilities, behavior changes, fixes that affected 
 
 ---
 
+## [4.0.4] - 2026-06-06
+
+Preserve acronym and proper-noun casing inside punctuation during autofix.
+
+### Fixed
+
+- The SC001 autofix no longer lowercases a configured acronym or proper noun
+  when it is wrapped in punctuation. `## Phase 2: The Structure (PARA)` now
+  autofixes to `the structure (PARA)` instead of `(para)`. The per-word
+  dictionary lookup now strips surrounding punctuation and re-wraps the
+  corrected casing, matching the validation path. (#290)
+
+---
+
 ## [4.0.3] - 2026-06-05
 
 Teach the sentence-case dictionary the Apple and Microsoft brand names.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-styleguide",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "keywords": [
     "markdownlint",
     "markdownlint-rule",

--- a/src/rules/sentence-case/fix-builder.js
+++ b/src/rules/sentence-case/fix-builder.js
@@ -64,42 +64,49 @@ export function toSentenceCase(text, specialCasedTerms, ambiguousTerms = {}) {
       return w;
     }
 
-    const lower = w.toLowerCase();
+    // Separate surrounding punctuation (e.g. "(PARA)", "Storj)") so the bare
+    // word still matches the casing dictionary, which is keyed on the word
+    // alone. Without this, "(PARA)" keys on "(para)", misses, and is
+    // lowercased even though validation (which strips punctuation) passes. (#290)
+    const lead = (w.match(/^[^\p{L}\p{N}]+/u) || [''])[0];
+    const trail = (w.match(/[^\p{L}\p{N}]+$/u) || [''])[0];
+    const core = w.slice(lead.length, w.length - trail.length);
+    const lowerCore = core.toLowerCase();
 
     // Preserve ambiguous terms - they could be common nouns or proper nouns
     // (e.g., "Word" could be common noun "word" or Microsoft Word)
     // But only preserve if they're already in valid form (capitalized like a proper noun)
     // Don't preserve ALL CAPS or all lowercase - convert those appropriately
-    if (ambiguousTerms[lower]) {
+    if (ambiguousTerms[lowerCore]) {
       if (!firstVisibleWordCased) {
         firstVisibleWordCased = true;
         // For first word, capitalize it appropriately
-        return w.charAt(0).toUpperCase() + w.slice(1).toLowerCase();
+        return lead + core.charAt(0).toUpperCase() + core.slice(1).toLowerCase() + trail;
       }
       // For subsequent words, check if it looks like a proper noun (first letter upper, rest lower)
       // If so, preserve it. If ALL CAPS or all lowercase, convert to lowercase.
-      const looksLikeProperNoun = /^[A-Z][a-z]/.test(w);
+      const looksLikeProperNoun = /^[A-Z][a-z]/.test(core);
       if (looksLikeProperNoun) {
         return w; // Preserve "Word" as-is
       }
-      return w.toLowerCase(); // Convert "WORD" or "word" to lowercase
+      return lead + core.toLowerCase() + trail; // Convert "WORD" or "word" to lowercase
     }
 
-    if (specialCasedTerms[lower]) {
+    if (specialCasedTerms[lowerCore]) {
       // Contextual ALL_CAPS terms (NOTE, TIP, etc.) should follow normal sentence case
       // unless the word is already ALL_CAPS in the input
-      if (contextualAllCapsTerms.has(lower) && w !== w.toUpperCase()) {
+      if (contextualAllCapsTerms.has(lowerCore) && core !== core.toUpperCase()) {
         if (!firstVisibleWordCased) {
           firstVisibleWordCased = true;
-          return w.charAt(0).toUpperCase() + w.slice(1).toLowerCase();
+          return lead + core.charAt(0).toUpperCase() + core.slice(1).toLowerCase() + trail;
         }
-        return w.toLowerCase();
+        return lead + core.toLowerCase() + trail;
       }
       // Special term counts as the first visible word if we haven't seen one yet
       if (!firstVisibleWordCased) {
         firstVisibleWordCased = true;
       }
-      return specialCasedTerms[lower];
+      return lead + specialCasedTerms[lowerCore] + trail;
     }
 
     if (!firstVisibleWordCased) {

--- a/tests/features/sentence-case-punctuated-acronyms.test.js
+++ b/tests/features/sentence-case-punctuated-acronyms.test.js
@@ -1,0 +1,62 @@
+// @ts-check
+
+/**
+ * @feature
+ * SC001 autofix must preserve configured acronyms and proper nouns that are
+ * wrapped in surrounding punctuation, e.g. `(PARA)` (#290). The per-word
+ * dictionary lookup previously used the whole token, so `(PARA)` keyed on
+ * `(para)` (absent) and fell through to lowercasing. Bare `PARA` worked.
+ */
+import { describe, test, expect } from '@jest/globals';
+import { lint } from 'markdownlint/promise';
+import { applyFixes } from 'markdownlint';
+import sentenceRule from '../../src/rules/sentence-case-heading.js';
+
+/**
+ * Lint with SC001 + config, then apply its fixes.
+ * @param {string} content
+ * @param {object} config
+ * @returns {Promise<string>}
+ */
+async function fixSC001(content, config) {
+  const results = await lint({
+    customRules: [sentenceRule],
+    config: { default: false, 'sentence-case-heading': config },
+    strings: { 'test.md': content },
+    resultVersion: 3,
+  });
+  return applyFixes(content, results['test.md'] || []);
+}
+
+describe('SC001 preserves acronyms/proper nouns in punctuation (#290)', () => {
+  test('acronym in parentheses keeps casing while sibling word lowercases', async () => {
+    const fixed = await fixSC001('## Phase 2: The Structure (PARA)\n', {
+      acronyms: ['PARA'],
+    });
+    expect(fixed).toBe('## Phase 2: the structure (PARA)\n');
+  });
+
+  test('acronym embedded in a parenthetical phrase keeps casing', async () => {
+    const fixed = await fixSC001('## iCloud Storage (PARA structure)\n', {
+      acronyms: ['PARA'],
+    });
+    // iCloud is a default brand; Storage lowercases; PARA stays uppercase
+    expect(fixed).toBe('## iCloud storage (PARA structure)\n');
+  });
+
+  test('proper noun with trailing paren keeps casing', async () => {
+    const fixed = await fixSC001(
+      '- **Fully protected (offsite via Storj)**\n',
+      { properNouns: ['Storj'] },
+    );
+    expect(fixed).toContain('Storj)');
+    expect(fixed).not.toContain('storj');
+  });
+
+  test('bare acronym (no punctuation) still preserved — control', async () => {
+    const fixed = await fixSC001('## The Structure PARA\n', {
+      acronyms: ['PARA'],
+    });
+    expect(fixed).toBe('## The structure PARA\n');
+  });
+});


### PR DESCRIPTION
## Summary

- The SC001 autofix lowercased a configured acronym or proper noun when it was wrapped in punctuation (e.g. `(PARA)` → `(para)`), because the per-word dictionary lookup used the whole token. Validation already strips punctuation, so the term was correctly *not flagged* — only the autofix mangled it.
- The fix strips leading/trailing punctuation for the lookup and re-wraps the corrected casing.
- Bumped to 4.0.4.

Closes #290

## Test plan

### Automated testing
- [x] New suite `sentence-case-punctuated-acronyms.test.js`: acronym in parens, acronym in a parenthetical phrase, proper noun with trailing paren, and a bare-acronym control.
- [x] Full suite green: 90 suites / 1711 tests, no regressions.
- [x] `eslint` and `npm run lint:md` clean.

## Breaking changes

None — fixes a destructive autofix.

## Documentation

- [x] CHANGELOG updated (4.0.4).