### PR TITLE
Preserve mixed-case proper nouns on sentence-case --fix

### DIFF
--- a/src/rules/sentence-case/fix-builder.js
+++ b/src/rules/sentence-case/fix-builder.js
@@ -78,6 +78,17 @@ export function toSentenceCase(text, specialCasedTerms, ambiguousTerms = {}) {
     // But only preserve if they're already in valid form (capitalized like a proper noun)
     // Don't preserve ALL CAPS or all lowercase - convert those appropriately
     if (ambiguousTerms[lowerCore]) {
+      // A deliberately mixed-case proper noun — an internal capital like
+      // "qBittorrent" or a leading digit/symbol like "1Password" — must survive
+      // --fix verbatim. Plain sentence-casing capitalizes the first character
+      // and lowercases the rest, silently renaming the product. All-caps forms
+      // are excluded so SemVer-style words (e.g. "PATCH") still normalize. (#305)
+      const isMixedCaseProperNoun =
+        core !== core.toUpperCase() && /\p{Lu}/u.test(core.slice(1));
+      if (isMixedCaseProperNoun) {
+        firstVisibleWordCased = true;
+        return w;
+      }
       if (!firstVisibleWordCased) {
         firstVisibleWordCased = true;
         // For first word, capitalize it appropriately

--- a/src/rules/sentence-case/fix-builder.js
+++ b/src/rules/sentence-case/fix-builder.js
@@ -81,13 +81,16 @@ export function toSentenceCase(text, specialCasedTerms, ambiguousTerms = {}) {
       // A deliberately mixed-case proper noun — an internal capital like
       // "qBittorrent" or a leading digit/symbol like "1Password" — must survive
       // --fix verbatim. Plain sentence-casing capitalizes the first character
-      // and lowercases the rest, silently renaming the product. All-caps forms
-      // are excluded so SemVer-style words (e.g. "PATCH") still normalize. (#305)
+      // and lowercases the rest, silently renaming the product. The input is
+      // preserved exactly as written rather than normalized to the configured
+      // proper form, because the allowed-both-ways contract must also let the
+      // lowercase homograph stay lowercase. All-caps forms are excluded so
+      // SemVer-style words (e.g. "PATCH") still normalize. (#305)
       const isMixedCaseProperNoun =
         core !== core.toUpperCase() && /\p{Lu}/u.test(core.slice(1));
       if (isMixedCaseProperNoun) {
         firstVisibleWordCased = true;
-        return w;
+        return lead + core + trail;
       }
       if (!firstVisibleWordCased) {
         firstVisibleWordCased = true;

--- a/tests/features/sentence-case-acronyms-propernouns.test.js
+++ b/tests/features/sentence-case-acronyms-propernouns.test.js
@@ -19,6 +19,8 @@ import sentenceRule from '../../src/rules/sentence-case-heading.js';
 
 /**
  * Lint then apply SC001 fixes, returning the autofixed content.
+ * Unlike `lintMarkdown`, this exercises the full lint-then-apply-fixes
+ * pipeline so tests can assert the exact `--fix` output.
  * @param {string} content Markdown content to lint and fix.
  * @param {Object} config sentence-case-heading configuration.
  * @returns {Promise<string>} The content after applying SC001 fixes.
@@ -128,6 +130,14 @@ describe('SC001 properNouns --fix preserves mixed-case (issue #305)', () => {
   test('test_should_preserve_mixed_case_proper_noun_in_bold_list_item', async () => {
     const fixed = await fixMarkdown('- **qBittorrent Setup**: notes', { properNouns: ['qBittorrent'] });
     expect(fixed).toBe('- **qBittorrent setup**: notes');
+  });
+
+  test('test_should_still_normalize_all_caps_ambiguous_term_when_fixing', async () => {
+    // Guards the `!== core.toUpperCase()` exclusion: all-caps SemVer-style terms
+    // (PATCH is a built-in ambiguous term) must keep normalizing, not be
+    // preserved verbatim by the mixed-case proper-noun branch.
+    const fixed = await fixMarkdown('## Understanding PATCH Releases');
+    expect(fixed).toBe('## Understanding patch releases');
   });
 });
 

--- a/tests/features/sentence-case-acronyms-propernouns.test.js
+++ b/tests/features/sentence-case-acronyms-propernouns.test.js
@@ -14,7 +14,27 @@
 
 import { describe, test, expect } from '@jest/globals';
 import { lint } from 'markdownlint/promise';
+import { applyFixes } from 'markdownlint';
 import sentenceRule from '../../src/rules/sentence-case-heading.js';
+
+/**
+ * Lint then apply SC001 fixes, returning the autofixed content.
+ * @param {string} content Markdown content to lint and fix.
+ * @param {Object} config sentence-case-heading configuration.
+ * @returns {Promise<string>} The content after applying SC001 fixes.
+ */
+async function fixMarkdown(content, config = {}) {
+  const results = await lint({
+    customRules: [sentenceRule],
+    strings: { testContent: content },
+    config: {
+      default: false,
+      'sentence-case-heading': config
+    },
+    resultVersion: 3
+  });
+  return applyFixes(content, results.testContent || []);
+}
 
 /**
  * Lint markdown content with the SC001 rule and a given config.
@@ -76,6 +96,38 @@ describe('SC001 acronyms (issue #233)', () => {
     const violations = await lintMarkdown('# A wysiwyg editor', { acronyms: ['WYSIWYG'] });
     expect(violations.length).toBeGreaterThan(0);
     expect(violations[0].errorDetail).toMatch(/WYSIWYG/);
+  });
+});
+
+describe('SC001 properNouns --fix preserves mixed-case (issue #305)', () => {
+  test('test_should_preserve_internal_capital_proper_noun_when_fixing', async () => {
+    const fixed = await fixMarkdown('## VPN + qBittorrent Stack', { properNouns: ['qBittorrent'] });
+    expect(fixed).toBe('## VPN + qBittorrent stack');
+  });
+
+  test('test_should_preserve_leading_digit_proper_noun_when_fixing', async () => {
+    const fixed = await fixMarkdown('## 1Password Items', { properNouns: ['1Password'] });
+    expect(fixed).toBe('## 1Password items');
+  });
+
+  test('test_should_preserve_proper_noun_as_first_word_when_fixing', async () => {
+    const fixed = await fixMarkdown('## qBittorrent Setup Guide', { properNouns: ['qBittorrent'] });
+    expect(fixed).toBe('## qBittorrent setup guide');
+  });
+
+  test('test_should_preserve_capitalized_ambiguous_proper_noun_when_fixing', async () => {
+    const fixed = await fixMarkdown('## Working With Craft Tools', { properNouns: ['Craft'] });
+    expect(fixed).toBe('## Working with Craft tools');
+  });
+
+  test('test_should_keep_lowercase_homograph_lowercase_when_fixing', async () => {
+    const fixed = await fixMarkdown('## Mastering Your craft Daily', { properNouns: ['Craft'] });
+    expect(fixed).toBe('## Mastering your craft daily');
+  });
+
+  test('test_should_preserve_mixed_case_proper_noun_in_bold_list_item', async () => {
+    const fixed = await fixMarkdown('- **qBittorrent Setup**: notes', { properNouns: ['qBittorrent'] });
+    expect(fixed).toBe('- **qBittorrent setup**: notes');
   });
 });
 


### PR DESCRIPTION
## Summary

- `--fix` no longer lowercases mixed-case `properNouns` entries in SC001
- Internal-capital names (`qBittorrent`) and leading-digit names (`1Password`) now survive autofix verbatim, while the trailing common word is still lowercased
- Root cause: the ambiguous-term branch in the fix builder applied plain sentence-casing (capitalize first char, lowercase the rest) and a `^[A-Z][a-z]` proper-noun heuristic that misses internal-capital and leading-digit forms

Closes #305

## Approach

In `toSentenceCase`, a word matching an allowed-both-ways term is now preserved verbatim when it is deliberately mixed-case — it contains an uppercase letter after the first character and is not all-caps. All-caps forms (e.g. SemVer `PATCH`) still normalize, and lowercase homographs (`craft`) still lowercase, so the "allowed both ways" semantics are unchanged.

## Test plan

### Automated testing
- [x] New feature tests cover internal-capital, leading-digit, first-word, bold-list-item, and homograph cases
- [x] Full Jest suite passes (`npm run validate`): 1717 passed
- [x] Verified the issue's exact reproduction now yields the expected output

### Test coverage
- [x] New behavior has tests (`tests/features/sentence-case-acronyms-propernouns.test.js`)
- [x] Tests follow behavioral naming

## Breaking changes

None — backward compatible. Built-in ambiguous terms and existing config behavior are unchanged.

## Documentation

- [x] No public API change; behavior now matches the documented `properNouns` intent