### PR TITLE
Fix BCE001 false flag for hyphen suffix after emphasis or inline code span

### DIFF
--- a/src/rules/backtick-code-elements.js
+++ b/src/rules/backtick-code-elements.js
@@ -352,6 +352,19 @@ function backtickCodeElements(params, onError) {
           continue;
         }
 
+        // Skip hyphenated compound suffixes immediately after an emphasis close
+        // (*Word*-style, _Word_-driven) or an inline code span (`code`-level).
+        // The `\B` anchor in the CLI flag pattern fires after `*`, `_`, and `` ` ``
+        // because those are non-word characters, causing false flags on compounds
+        // like *Acme*-style and `Documents`-level (#301, #306).
+        if (
+          /^-[a-zA-Z]/.test(fullMatch) &&
+          start > 0 &&
+          /[*_`]/.test(line[start - 1])
+        ) {
+          continue;
+        }
+
         // Skip ellipsis-joined prose words, e.g. "only...but" or "system…was" (#196).
         // Covers both the full match (e.g. "only...but") and sub-matches like "..but"
         // that occur because the dotfile pattern fires inside "word...word".

--- a/tests/features/backtick-emphasis-hyphen-suffix.test.js
+++ b/tests/features/backtick-emphasis-hyphen-suffix.test.js
@@ -1,0 +1,153 @@
+/**
+ * @feature
+ * Tests for issue #301: BCE001 should not flag hyphenated English suffixes
+ * as CLI flags when the preceding word is wrapped in emphasis markers (*...*
+ * or _..._).
+ *
+ * Tests for issue #306: BCE001 --fix must not emit doubled backticks when
+ * a hyphenated suffix immediately follows an existing inline code span.
+ */
+import { describe, test, expect } from "@jest/globals";
+import { lint } from "markdownlint/promise";
+import { applyFixes } from "markdownlint";
+import backtickRule from "../../src/rules/backtick-code-elements.js";
+
+/**
+ * Helper to lint a markdown string and return only BCE001 violations.
+ * @param {string} markdown - Markdown content to lint.
+ * @returns {Promise<Array>} BCE001 violations.
+ */
+async function getBCE001Violations(markdown) {
+  const options = {
+    customRules: [backtickRule],
+    strings: { "test.md": markdown },
+    resultVersion: 3,
+  };
+  const results = await lint(options);
+  const violations = results["test.md"] || [];
+  return violations.filter(
+    (v) =>
+      v.ruleNames.includes("backtick-code-elements") ||
+      v.ruleNames.includes("BCE001"),
+  );
+}
+
+/**
+ * Helper: lint markdown, apply fixes, return the fixed string.
+ * @param {string} markdown
+ * @returns {Promise<string>}
+ */
+async function applyBCE001Fixes(markdown) {
+  const options = {
+    customRules: [backtickRule],
+    strings: { "test.md": markdown },
+    resultVersion: 3,
+  };
+  const results = await lint(options);
+  const violations = (results["test.md"] || []).filter(
+    (v) =>
+      v.ruleNames.includes("backtick-code-elements") ||
+      v.ruleNames.includes("BCE001"),
+  );
+  return applyFixes(markdown, violations);
+}
+
+// ---------------------------------------------------------------------------
+// #301 — emphasis-adjacent hyphen suffix not flagged
+// ---------------------------------------------------------------------------
+
+describe("BCE001 emphasis-adjacent hyphen suffix (#301)", () => {
+  test("does not flag *Word*-style compound", async () => {
+    const violations = await getBCE001Violations(
+      "We chose an *Acme*-style layout.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag *Word*-driven compound", async () => {
+    const violations = await getBCE001Violations(
+      "The team prefers a *Foo*-driven workflow.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag *Word*-based compound", async () => {
+    const violations = await getBCE001Violations(
+      "A *React*-based application handles this.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag *Word*-like compound", async () => {
+    const violations = await getBCE001Violations(
+      "Use a *Unix*-like environment for development.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag underscore emphasis _Word_-style compound", async () => {
+    const violations = await getBCE001Violations(
+      "We chose a _Acme_-style layout.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag multiple emphasis-hyphen compounds on one line", async () => {
+    const violations = await getBCE001Violations(
+      "A *Foo*-style and *Bar*-driven approach.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("plain prose compound without emphasis is still not flagged", async () => {
+    // The existing suffix fix (#145/#193) handles plain prose — this remains correct.
+    const violations = await getBCE001Violations(
+      "A plain modern-style layout, with no emphasis.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("real CLI flags after emphasis are still flagged", async () => {
+    // *command* --verbose should still flag --verbose
+    const violations = await getBCE001Violations(
+      "Run *git* --verbose to see output.",
+    );
+    expect(violations.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #306 — --fix must not emit doubled backticks next to an existing code span
+// ---------------------------------------------------------------------------
+
+describe("BCE001 --fix no doubled backticks adjacent to code span (#306)", () => {
+  test("does not flag code-span followed by hyphen suffix", async () => {
+    // `Documents`-level → -level is a suffix, not a flag
+    const violations = await getBCE001Violations(
+      "Synology Drive Client runs for `Documents`-level live sync.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag code-span followed by -anchored suffix", async () => {
+    const violations = await getBCE001Violations(
+      "Python 2's `re.split` with a `^`-anchored lookahead has edge cases.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("fix output contains no doubled backticks for code-span-hyphen compound", async () => {
+    // Even if a violation were reported, the fix must not emit ``
+    const markdown =
+      "Synology Drive Client runs for `Documents`-level live sync.";
+    const fixed = await applyBCE001Fixes(markdown);
+    expect(fixed).not.toContain("``");
+  });
+
+  test("fix output contains no doubled backticks for second code-span-hyphen compound", async () => {
+    const markdown =
+      "Python 2's `re.split` with a `^`-anchored lookahead has edge cases.";
+    const fixed = await applyBCE001Fixes(markdown);
+    expect(fixed).not.toContain("``");
+  });
+});


### PR DESCRIPTION
## Summary

- BCE001 was matching `-word` as a CLI flag when the preceding character was `*`, `_`, or `` ` `` (emphasis close or code-span close), because `\B` fires at those non-word boundaries — turning `*Acme*-style` into a false positive
- The fix checks whether a single-hyphen match is immediately preceded by an emphasis or code-span close marker and skips it — recognising the pattern as a hyphenated compound suffix, not a command option
- As a side-effect, `--fix` can no longer emit doubled backticks (`` `` `` ) adjacent to an existing code span, because the false flag that would trigger the fix is suppressed at the detection stage

Closes #301
Closes #306

## Test plan

### Automated testing
- [x] New feature test file `tests/features/backtick-emphasis-hyphen-suffix.test.js` — 12 tests covering emphasis-adjacent (`*Word*-style`, `_Word_-driven`) and code-span-adjacent (`` `Documents`-level ``) false positives, plus a doubled-backtick regression check
- [x] Full Jest suite passes (1730 tests, 91 suites)
- [x] ESLint passes

### Manual testing
- [x] Verified `*Acme*-style`, `*Foo*-driven`, `_Acme_-style` no longer flagged
- [x] Verified `` `Documents`-level ``, `` `^`-anchored `` no longer flagged
- [x] Verified real flags after emphasis (`*git* --verbose`) are still flagged