### PR TITLE
Exclude gitignored paths (node_modules) from mdsg init by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ npx mdsg init --preset recommended
 npx markdownlint-cli2 "**/*.md"
 ```
 
+The generated config includes `"gitignore": true`, so markdownlint-cli2 automatically skips `node_modules` and any other paths listed in `.gitignore`.
+
 ## Rules
 
 | Rule | ID | Auto-fix | Purpose |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,7 +47,7 @@ Bootstrap starters in `templates/` for new consumer repos:
 - `markdownlint-cli2-*.jsonc` — for CLI usage (CI pipelines, pre-commit hooks). Uses `extends` to inherit from the corresponding preset.
 - `vscode-settings-*.jsonc` — for the VS Code markdownlint extension (different config shape)
 
-CLI templates use `extends` to inherit all rules from the preset. Distribution creates these once via `skipIfExists` and never overwrites them, so repo-specific overrides are preserved.
+CLI templates use `extends` to inherit all rules from the preset. They also include `"gitignore": true` so markdownlint-cli2 skips `node_modules` and any other paths listed in `.gitignore` by default. Distribution creates these once via `skipIfExists` and never overwrites them, so repo-specific overrides are preserved.
 
 ## Consumer repo setup
 

--- a/templates/markdownlint-cli2-basic.jsonc
+++ b/templates/markdownlint-cli2-basic.jsonc
@@ -1,6 +1,7 @@
 {
   // Basic configuration for markdownlint-styleguide
   // Inherits all rules from the basic preset
+  "gitignore": true,
   "customRules": [
     "markdownlint-styleguide"
   ],

--- a/templates/markdownlint-cli2-recommended.jsonc
+++ b/templates/markdownlint-cli2-recommended.jsonc
@@ -1,6 +1,7 @@
 {
   // Recommended configuration for markdownlint-styleguide
   // Inherits all rules from the recommended preset
+  "gitignore": true,
   "customRules": [
     "markdownlint-styleguide"
   ],

--- a/templates/markdownlint-cli2-strict.jsonc
+++ b/templates/markdownlint-cli2-strict.jsonc
@@ -1,6 +1,7 @@
 {
   // Strict configuration for markdownlint-styleguide
   // Inherits all rules from the strict preset
+  "gitignore": true,
   "customRules": [
     "markdownlint-styleguide"
   ],

--- a/tests/unit/init.test.js
+++ b/tests/unit/init.test.js
@@ -662,6 +662,38 @@ describe('init.cjs', () => {
     });
   });
 
+  describe('gitignore exclusion', () => {
+    it('should include "gitignore": true in generated basic CLI config', () => {
+      execSync('node ' + scriptPath + ' --preset basic --cli', {
+        cwd: tempDir,
+      });
+
+      const cliConfig = path.join(tempDir, '.markdownlint-cli2.jsonc');
+      const content = parseJsonc(fs.readFileSync(cliConfig, 'utf8'));
+      expect(content.gitignore).toBe(true);
+    });
+
+    it('should include "gitignore": true in generated recommended CLI config', () => {
+      execSync('node ' + scriptPath + ' --preset recommended --cli', {
+        cwd: tempDir,
+      });
+
+      const cliConfig = path.join(tempDir, '.markdownlint-cli2.jsonc');
+      const content = parseJsonc(fs.readFileSync(cliConfig, 'utf8'));
+      expect(content.gitignore).toBe(true);
+    });
+
+    it('should include "gitignore": true in generated strict CLI config', () => {
+      execSync('node ' + scriptPath + ' --preset strict --cli', {
+        cwd: tempDir,
+      });
+
+      const cliConfig = path.join(tempDir, '.markdownlint-cli2.jsonc');
+      const content = parseJsonc(fs.readFileSync(cliConfig, 'utf8'));
+      expect(content.gitignore).toBe(true);
+    });
+  });
+
   describe('config validation', () => {
     it('should validate config after creation', () => {
       const output = execSync('node ' + scriptPath + ' --preset recommended', {


### PR DESCRIPTION
## Summary

- Adds `"gitignore": true` to all three CLI config templates (`basic`, `recommended`, `strict`)
- markdownlint-cli2 automatically skips `node_modules` and any other path in `.gitignore`, eliminating ~3,800 noise findings per fresh consumer install
- Documents the behavior in README quick start and `docs/configuration.md`

Closes #300

## Test plan

### Automated testing
- [x] New unit tests assert each preset's generated `.markdownlint-cli2.jsonc` includes `"gitignore": true`
- [x] Full test suite passes (`npm test -- --maxWorkers=2`)
- [x] ESLint passes (`npm run lint`)

### Manual testing
- [x] `mdsg init --preset basic --cli` produces config with `"gitignore": true`
- [x] `mdsg init --preset recommended --cli` produces config with `"gitignore": true`
- [x] `mdsg init --preset strict --cli` produces config with `"gitignore": true`

## Breaking changes

None — the generated config is new to each consumer install; `"gitignore": true` is additive and only skips files already excluded from version control.