### PR TITLE
Fix no-literal-ampersand exceptions: wire flat config and position-aware phrase matching

### DIFF
--- a/src/rules/no-literal-ampersand.js
+++ b/src/rules/no-literal-ampersand.js
@@ -142,10 +142,20 @@ function shouldFlagAmpersand(line, position, skipInlineCode, exceptions, context
   // Use position-aware matching so only the & that is part of the
   // exception phrase is exempted, not every & on the same line.
   for (const exception of exceptions) {
+    // Skip empty patterns: an empty string compiles to a zero-width regex
+    // that matches at index 0 without advancing lastIndex, hanging the loop.
+    if (!exception) {
+      continue;
+    }
     const escaped = exception.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const regex = new RegExp(escaped, 'gi');
     let match;
     while ((match = regex.exec(line)) !== null) {
+      // Defensive guard against any zero-width match advancing nowhere.
+      if (match[0].length === 0) {
+        regex.lastIndex += 1;
+        continue;
+      }
       const start = match.index;
       const end = start + match[0].length - 1;
       if (position >= start && position <= end) {

--- a/src/rules/no-literal-ampersand.js
+++ b/src/rules/no-literal-ampersand.js
@@ -138,11 +138,19 @@ function shouldFlagAmpersand(line, position, skipInlineCode, exceptions, context
     }
   }
 
-  // Check if this ampersand matches any exception patterns
+  // Check if this ampersand falls within any exception phrase.
+  // Use position-aware matching so only the & that is part of the
+  // exception phrase is exempted, not every & on the same line.
   for (const exception of exceptions) {
-    const regex = new RegExp(exception.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
-    if (regex.test(line)) {
-      return false;
+    const escaped = exception.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(escaped, 'gi');
+    let match;
+    while ((match = regex.exec(line)) !== null) {
+      const start = match.index;
+      const end = start + match[0].length - 1;
+      if (position >= start && position <= end) {
+        return false;
+      }
     }
   }
 
@@ -170,7 +178,7 @@ function noLiteralAmpersand(params, onError) {
     return;
   }
 
-  const config = params.config?.['no-literal-ampersand'] || params.config?.NLA001 || {};
+  const config = params.config?.['no-literal-ampersand'] || params.config?.NLA001 || params.config || {};
 
   // Validate configuration
   const configSchema = {

--- a/tests/features/no-literal-ampersand.test.js
+++ b/tests/features/no-literal-ampersand.test.js
@@ -55,6 +55,32 @@ function runRuleWithContent(markdown) {
   return errors;
 }
 
+/**
+ * Run the rule with a flat config object (markdownlint-cli2 form: params.config IS the config).
+ * @param {string} markdown
+ * @param {object} config - flat config, e.g. { exceptions: ['Foo & Bar'] }
+ * @returns {Array} Array of errors
+ */
+function runRuleWithConfig(markdown, config) {
+  const errors = [];
+  const onError = (error) => errors.push(error);
+
+  // In markdownlint-cli2, params.config IS the flat config object for the rule.
+  const params = {
+    name: 'test.md',
+    lines: markdown.split('\n'),
+    config,
+    parsers: {
+      micromark: {
+        tokens: []
+      }
+    }
+  };
+
+  noLiteralAmpersandRule.function(params, onError);
+  return errors;
+}
+
 describe('no-literal-ampersand rule', () => {
   const fixturesDir = path.resolve(__dirname, '../fixtures/no-literal-ampersand');
   const passingFixture = path.join(fixturesDir, 'passing.fixture.md');
@@ -234,6 +260,48 @@ function test() {
       
       // Should flag the first and third & but not the one in code
       expect(errors).toHaveLength(2);
+    });
+  });
+
+  describe('exceptions config — flat form (#304)', () => {
+    test('flat { exceptions: [...] } config suppresses flagged phrase in prose', () => {
+      // params.config IS the flat object — the || params.config fallback must be present
+      const markdown = 'See the User & Group settings page.';
+      const errors = runRuleWithConfig(markdown, { exceptions: ['User & Group'] });
+      expect(errors).toHaveLength(0);
+    });
+
+    test('flat config exceptions do not suppress unrelated ampersands', () => {
+      const markdown = 'See the User & Group page and also dogs & cats.';
+      const errors = runRuleWithConfig(markdown, { exceptions: ['User & Group'] });
+      // "dogs & cats" should still be flagged
+      expect(errors).toHaveLength(1);
+      expect(errors[0].detail).toContain('Use "and" instead of literal ampersand (&)');
+    });
+
+    test('flat config exceptions work as substring match in headings (#298)', () => {
+      const markdown = '### Foo & Bar\n\nSome prose about it.';
+      const errors = runRuleWithConfig(markdown, { exceptions: ['Foo & Bar'] });
+      expect(errors).toHaveLength(0);
+    });
+
+    test('flat config exceptions work as substring match in regular prose (#298)', () => {
+      const markdown = 'See the Foo & Bar section for details.';
+      const errors = runRuleWithConfig(markdown, { exceptions: ['Foo & Bar'] });
+      expect(errors).toHaveLength(0);
+    });
+
+    test('unconfigured ampersand in prose is still flagged when exceptions present', () => {
+      const markdown = 'Dogs & cats.\n\n### Foo & Bar';
+      const errors = runRuleWithConfig(markdown, { exceptions: ['Foo & Bar'] });
+      // "dogs & cats" in prose should still be flagged; heading "Foo & Bar" is excepted
+      expect(errors).toHaveLength(1);
+    });
+
+    test('multiple exceptions suppress multiple phrases', () => {
+      const markdown = 'User & Group plus Foo & Bar are both fine.';
+      const errors = runRuleWithConfig(markdown, { exceptions: ['User & Group', 'Foo & Bar'] });
+      expect(errors).toHaveLength(0);
     });
   });
 

--- a/tests/features/no-literal-ampersand.test.js
+++ b/tests/features/no-literal-ampersand.test.js
@@ -303,6 +303,16 @@ function test() {
       const errors = runRuleWithConfig(markdown, { exceptions: ['User & Group', 'Foo & Bar'] });
       expect(errors).toHaveLength(0);
     });
+
+    test('empty exception string does not hang and is ignored', () => {
+      const markdown = 'Dogs & cats.';
+      const errors = runRuleWithConfig(markdown, { exceptions: [''] });
+      // An empty pattern must be skipped (no zero-width infinite loop) and
+      // must not suppress a genuine literal ampersand. The config-validation
+      // layer also surfaces the empty entry as a configuration error.
+      expect(errors.some((e) => e.detail.includes('literal ampersand'))).toBe(true);
+      expect(errors.some((e) => e.detail.includes('Configuration'))).toBe(true);
+    });
   });
 
   describe('rule metadata', () => {


### PR DESCRIPTION
## Summary

- Adds `|| params.config` fallback so the flat markdownlint-cli2 config form (where `params.config` IS the rule's config object) is read correctly — without it, `exceptions` was silently dropped
- Replaces whole-line exception matching with position-aware scan: only the `&` that physically falls inside a matched exception phrase is exempted, so `"User & Group plus dogs & cats"` with exception `["User & Group"]` still flags the second `&`
- Adds feature tests covering both the flat-config wiring and position-aware substring matching in headings and prose

Closes #298, closes #304

## Test plan

### Automated testing
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Full test suite passes (`npm test -- --maxWorkers=2`: 1724 passed, 9 skipped)

### Manual testing
- [x] `{ "exceptions": ["Foo & Bar"] }` (flat form) suppresses `&` in "see the Foo & Bar section" but still flags "dogs & cats"
- [x] Heading `### Foo & Bar` with exception `["Foo & Bar"]` produces no violations
- [x] Multiple exceptions suppress multiple phrases on the same line independently

### Test coverage
- [x] New functionality has tests (`tests/features/no-literal-ampersand.test.js` — 6 new cases under "exceptions config — flat form (#304)")