### PR TITLE
Fix SC001 false positives for parenthesized multi-word proper nouns

### DIFF
--- a/src/rules/sentence-case/case-classifier.js
+++ b/src/rules/sentence-case/case-classifier.js
@@ -174,6 +174,16 @@ function findFirstValidationWord(words) {
 }
 
 /**
+ * Strips leading and trailing non-alphanumeric punctuation from a token for
+ * phrase matching purposes (e.g. "(okta" → "okta", "verify)" → "verify").
+ * @param {string} token The token to normalize.
+ * @returns {string} The normalized token.
+ */
+function normalizeToken(token) {
+  return token.replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, '');
+}
+
+/**
  * Determine indices of words that are part of multi-word proper nouns.
  * @param {string[]} words - Tokenized heading words.
  * @param {Object} specialCasedTerms Special casing terms.
@@ -181,7 +191,7 @@ function findFirstValidationWord(words) {
  */
 function getProperPhraseIndices(words, specialCasedTerms) {
   const indices = new Set();
-  const lowerWords = words.map((w) => w.toLowerCase());
+  const lowerWords = words.map((w) => normalizeToken(w).toLowerCase());
   Object.keys(specialCasedTerms).forEach((key) => {
     if (!key.includes(' ')) {
       return;

--- a/tests/unit/sentence-case-classifier.test.js
+++ b/tests/unit/sentence-case-classifier.test.js
@@ -712,3 +712,38 @@ describe("validateHeading — hyphenated special term matches whole token", () =
     expect(result.isValid).toBe(true);
   });
 });
+
+describe("validateBoldText — #303 parenthesized multi-word proper nouns", () => {
+  // When a multi-word proper noun like "Okta Verify" is wrapped in parentheses,
+  // the tokens include surrounding punctuation (e.g. "(okta" and "verify)") which
+  // must be stripped before phrase matching so the phrase is recognized and its
+  // words are not flagged as casing violations.
+  const terms303 = { "okta verify": "Okta Verify" };
+
+  test("parenthesized multi-word proper noun does not flag the second word (#303)", () => {
+    // Bold text that starts capitalized and contains a parenthesized multi-word term.
+    // Previously "Verify)" was flagged because the phrase match failed on tokens with
+    // surrounding punctuation.
+    const result = validateBoldText(
+      "Sign in using (Okta Verify) for authentication",
+      terms303,
+    );
+    expect(result.isValid).toBe(true);
+  });
+
+  test("multi-word proper noun with trailing comma does not flag the second word (#303)", () => {
+    const result = validateBoldText(
+      "Please set up Okta Verify, the authenticator app",
+      terms303,
+    );
+    expect(result.isValid).toBe(true);
+  });
+
+  test("genuinely miscased multi-word proper noun is still flagged (#303 regression)", () => {
+    const result = validateBoldText(
+      "Please set up okta verify before proceeding",
+      terms303,
+    );
+    expect(result.isValid).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- `getProperPhraseIndices` now strips leading/trailing non-alphanumeric punctuation from each token before comparing against phrase parts
- Covers `(Okta Verify)` (parenthesized) and `Okta Verify,` (trailing comma) without regressing single-word or bare multi-word paths
- The single-word path in `word-validators.js` already stripped parens; this brings `getProperPhraseIndices` into consistency with it

Closes #303

## Test plan

### Automated testing
- [x] New unit tests: parenthesized multi-word proper noun passes, trailing-comma variant passes, genuinely miscased phrase still fails
- [x] Full test suite passes (1730 tests)
- [x] ESLint clean

### Manual testing
- [x] Verified `validateBoldText("Sign in using (Okta Verify) for authentication", { "okta verify": "Okta Verify" })` returns `{ isValid: true }`
- [x] Verified `validateBoldText("Please set up okta verify before proceeding", ...)` still returns `{ isValid: false }`

## Breaking changes

None — backward compatible; only broadens what punctuation-wrapped tokens are recognized as part of an allowlisted phrase.