### PR TITLE
Fix BU001 to detect bare URLs without markdown-it linkify

### DIFF
--- a/src/rules/no-bare-urls.js
+++ b/src/rules/no-bare-urls.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Rule to enforce that URLs are always wrapped in a proper Markdown link.
- * @author 
+ * @author
  */
 
 import {
@@ -10,6 +10,7 @@ import {
   createMarkdownlintLogger
 } from './config-validation.js';
 import { createSafeFixInfo } from './autofix-safety.js';
+import { buildLineContext } from './shared-context.js';
 
 /**
  * @typedef {import("markdownlint").Rule} Rule
@@ -18,68 +19,82 @@ import { createSafeFixInfo } from './autofix-safety.js';
  */
 
 /**
- * Create autofix information to wrap a bare URL in angle brackets
- * @param {Object} linkToken - The link_open token
- * @param {Object} parentToken - The parent inline token
- * @param {number} childIndex - Index of the link_open token in children
- * @param {string[]} lines - Array of source lines
- * @returns {Object|null} Fix information for markdownlint
+ * Regex that matches bare URLs: http://, https://, or www. patterns.
+ *
+ * Matches from the protocol/www prefix through non-whitespace characters.
+ * Trailing punctuation is stripped in post-processing by
+ * {@link trimTrailingPunctuation}.
+ *
+ * Negative lookbehinds:
+ * - `(?<!<)` — skip autolinks: <https://...>
+ * - `(?<!\]\()` — skip link destinations: [text](https://...)
  */
-function createAutoFix(linkToken, parentToken, childIndex, lines) {
-  try {
-    const lineNumber = linkToken.lineNumber;
-    const line = lines[lineNumber - 1];
-    if (!line) return null;
-    
-    // Find the text token (should be the next child after link_open)
-    const textToken = parentToken.children[childIndex + 1];
-    if (!textToken || textToken.type !== 'text') return null;
-    
-    const url = textToken.content;
-    if (!url) return null;
-    
-    // Use the token's line/column information if available
-    // markdown-it provides accurate position data through the map property
-    let urlStart = -1;
-    
-    if (textToken.map && textToken.map.length >= 2) {
-      // Try to use the token's position mapping
-      const tokenStart = textToken.map[0];
-      urlStart = line.indexOf(url, tokenStart);
-    }
-    
-    // Fallback: search for the URL in the line
-    if (urlStart === -1) {
-      urlStart = line.indexOf(url);
-    }
-    
-    // If still not found, try without protocol for cases where markdown-it normalizes
-    if (urlStart === -1) {
-      // Try to find the URL without protocol
-      const urlWithoutProtocol = url.replace(/^https?:\/\//, '');
-      urlStart = line.indexOf(urlWithoutProtocol);
-      if (urlStart !== -1) {
-        // Adjust the URL to match what's actually in the text
-        const actualUrl = urlWithoutProtocol;
-        return {
-          editColumn: urlStart + 1, // 1-based column
-          deleteCount: actualUrl.length,
-          insertText: `<${actualUrl}>`
-        };
+const BARE_URL_RE =
+  /(?<!<)(?<!\]\()(?:https?:\/\/|www\.)\S+/g;
+
+/**
+ * Detect autolink ranges `<url>` on a line.
+ *
+ * Autolinks look like `<https://example.com>` or `<http://...>`. We need to
+ * skip any URL match that falls inside one of these so the rule does not
+ * double-report or flag already-correct usage.
+ *
+ * @param {string} line - Source line.
+ * @returns {Array<[number, number]>} `[start, end)` column ranges of autolinks.
+ */
+function autolinkRanges(line) {
+  const ranges = /** @type {Array<[number, number]>} */ ([]);
+  const re = /<(?:https?:\/\/|www\.)[^\s>]*>/g;
+  let m;
+  while ((m = re.exec(line)) !== null) {
+    ranges.push([m.index, m.index + m[0].length]);
+  }
+  return ranges;
+}
+
+/**
+ * Check whether a column falls inside any of the given ranges.
+ *
+ * @param {Array<[number, number]>} ranges - `[start, end)` ranges.
+ * @param {number} col - Zero-based column to test.
+ * @returns {boolean}
+ */
+function inRanges(ranges, col) {
+  return ranges.some(([start, end]) => col >= start && col < end);
+}
+
+/**
+ * Strip trailing punctuation from a URL match so we don't include sentence-
+ * ending characters that are not part of the URL.
+ *
+ * Handles:
+ * - Trailing `.`, `,`, `!`, `?`, `;`, `:` — sentence punctuation
+ * - Trailing `)` only when it has no matching `(` inside the URL
+ *   (balanced parens like Wikipedia URLs stay intact)
+ * - Trailing `>`, `"`, `'` — markup characters
+ *
+ * Iterates until no more trimming is possible so that combined trailing chars
+ * like `.).` are fully stripped.
+ *
+ * @param {string} url - Raw URL string from the regex match.
+ * @returns {string} URL with trailing punctuation removed.
+ */
+function trimTrailingPunctuation(url) {
+  let prev;
+  do {
+    prev = url;
+    // Strip trailing sentence punctuation and unmatched closing brackets.
+    url = url.replace(/[.,!?;:<>"']+$/, '');
+    // Strip a trailing `)` only if there is no unmatched `(` inside the URL.
+    if (url.endsWith(')')) {
+      const opens = (url.match(/\(/g) || []).length;
+      const closes = (url.match(/\)/g) || []).length;
+      if (closes > opens) {
+        url = url.slice(0, -1);
       }
     }
-    
-    if (urlStart === -1) return null;
-    
-    return {
-      editColumn: urlStart + 1, // 1-based column
-      deleteCount: url.length,
-      insertText: `<${url}>`
-    };
-  } catch (error) {
-    // If we can't create a fix, return null to skip autofix
-    return null;
-  }
+  } while (url !== prev);
+  return url;
 }
 
 /** @type {Rule} */
@@ -87,19 +102,19 @@ export default {
   names: ["no-bare-url", "BU001"],
   description: "Bare URL used. Surround with < and >.",
   tags: ["links", "url"],
+  parser: "none",
   information: new URL("https://github.com/davidanson/markdownlint/blob/main/doc/md034.md"),
-  function: 
+  function:
     /**
      * @param {RuleParams} params
      * @param {RuleOnError} onError
      */
     function rule(params, onError) {
-      // This rule relies on markdown-it's linkify option to identify bare URLs.
-      // It flags any URL that was automatically converted into a link.
-      // The fix is to wrap the URL in angle brackets, e.g., <http://example.com>.
-      // Note: Ensure markdown-it is configured with { linkify: true } in your test setup.
-      
-      const config = params.config?.['no-bare-url'] || params.config?.BU001 || {};
+      // params.config is already scoped to this rule by markdownlint.
+      // When the top-level config is { "no-bare-url": true }, params.config is
+      // true (boolean); when it is { "no-bare-url": { allowedDomains: [...] } },
+      // params.config is { allowedDomains: [...] }.
+      const config = (params.config && typeof params.config === 'object') ? params.config : {};
 
       // Validate configuration
       const configSchema = {
@@ -115,56 +130,84 @@ export default {
 
       // Extract configuration with defaults
       const allowedDomains = Array.isArray(config.allowedDomains) ? config.allowedDomains : [];
-      params.tokens.filter(t => t.type === "inline" && t.children).forEach(token => {
-        token.children.forEach((child, childIndex) => {
-          if (child.type === "link_open" && child.info === "auto" && child.markup !== "autolink") {
-            const href = child.attrGet("href");
 
-            // Skip markdown file references that were auto-linkified
-            // markdown-it's linkify treats ".md" as a domain (e.g., "SKILL.md" → "http://SKILL.md")
-            // These are not real URLs - they're file references in documentation
-            if (href && /^https?:\/\/[^/]+\.md$/i.test(href)) {
-              // Check if the original text doesn't contain http/https
-              // This indicates markdown-it added the protocol, not the author
-              const textToken = token.children[childIndex + 1];
-              if (textToken && textToken.type === 'text') {
-                const originalText = textToken.content;
-                if (!/^https?:\/\//i.test(originalText)) {
-                  return; // Skip - this is a markdown file reference, not a bare URL
-                }
-              }
-            }
+      const lines = params.lines;
+      const ctx = buildLineContext(lines);
 
-            // Check if this URL domain is in the allowed list
-            if (allowedDomains.length > 0) {
-              try {
-                const url = new URL(href);
-                if (allowedDomains.includes(url.hostname)) {
-                  return; // Skip allowed domains
-                }
-              } catch (e) {
-                // If URL parsing fails, proceed with the error
-              }
-            }
-            
-            // Create autofix that wraps the URL in angle brackets
-            const basicFixInfo = createAutoFix(child, token, childIndex, params.lines);
-            const safeFixInfo = basicFixInfo ? createSafeFixInfo(
-              basicFixInfo,
-              'no-bare-url',
-              href,
-              basicFixInfo.insertText,
-              { line: params.lines[child.lineNumber - 1] }
-            ) : null;
-            
-            onError({ 
-              lineNumber: child.lineNumber, 
-              detail: "Bare URL used.", 
-              context: href,
-              fixInfo: safeFixInfo
-            });
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+
+        // Skip lines that are entirely inside a fenced code block or frontmatter.
+        if (ctx.isInFencedCode(i) || ctx.isInFrontmatter(i)) {
+          continue;
+        }
+
+        // Skip reference link definitions: `[label]: url` or `[label]: url "title"`.
+        // These are not bare URLs in prose — they are part of Markdown link syntax.
+        if (/^\s{0,3}\[[^\]]+\]:\s/.test(line)) {
+          continue;
+        }
+
+        // Precompute autolink ranges for this line so we can skip them cheaply.
+        const autolinks = autolinkRanges(line);
+
+        // Scan for bare URL matches using the regex.
+        BARE_URL_RE.lastIndex = 0;
+        let match;
+        while ((match = BARE_URL_RE.exec(line)) !== null) {
+          let url = match[0];
+          let urlStart = match.index;
+
+          // Strip trailing punctuation that slipped through the regex.
+          const stripped = trimTrailingPunctuation(url);
+          if (stripped.length < url.length) {
+            url = stripped;
+            // Do NOT change urlStart — the URL still begins at the same column.
           }
-        });
-      });
+
+          // If stripping left nothing meaningful, skip.
+          if (!url || url.length < 4) continue;
+
+          // Check per-column contexts for the start of the URL.
+          if (ctx.isInInlineCode(i, urlStart)) continue;
+          if (ctx.isInLinkDestination(i, urlStart)) continue;
+          if (ctx.isInHtmlComment(i, urlStart)) continue;
+
+          // Skip if the URL is inside an autolink <url>.
+          if (inRanges(autolinks, urlStart)) continue;
+
+          // Apply allowedDomains filter.
+          if (allowedDomains.length > 0) {
+            try {
+              const urlObj = new URL(url.startsWith('www.') ? `https://${url}` : url);
+              if (allowedDomains.includes(urlObj.hostname)) continue;
+            } catch (_e) {
+              // If we can't parse, proceed to flag it.
+            }
+          }
+
+          // Build autofix: replace the bare URL with <url>.
+          const editColumn = urlStart + 1; // 1-based
+          const basicFixInfo = {
+            editColumn,
+            deleteCount: url.length,
+            insertText: `<${url}>`
+          };
+          const safeFixInfo = createSafeFixInfo(
+            basicFixInfo,
+            'no-bare-url',
+            url,
+            basicFixInfo.insertText,
+            { line }
+          );
+
+          onError({
+            lineNumber: i + 1,
+            detail: 'Bare URL used.',
+            context: url,
+            fixInfo: safeFixInfo
+          });
+        }
+      }
     },
 };

--- a/tests/features/no-bare-urls.test.js
+++ b/tests/features/no-bare-urls.test.js
@@ -2,7 +2,6 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { describe, test, expect, beforeAll } from "@jest/globals";
 import { lint } from "markdownlint/promise";
-import MarkdownIt from "markdown-it";
 import noBareUrls from "../../src/rules/no-bare-urls.js";
 import { parseFixture } from "../utils/fixture.js";
 
@@ -31,7 +30,6 @@ describe("no-bare-urls-trap rule", () => {
         "no-bare-url": true,
         MD034: false,
       },
-      markdownItFactory: () => new MarkdownIt({ linkify: true }),
     };
     violations = await lint(options);
   });
@@ -72,6 +70,69 @@ describe("no-bare-urls-trap rule", () => {
   });
 
   /**
+   * Regression: BU001 must fire without linkify enabled (the default for
+   * markdownlint-cli2). Previously the rule relied on markdown-it linkifying
+   * bare URLs into autolink tokens; without linkify those tokens never appeared
+   * and the rule was silently inert.
+   */
+  test("fires without linkify enabled (regression: BU001 inert under markdownlint-cli2)", async () => {
+    const bare = "See https://example.com for details.";
+    const results = await lint({
+      strings: { "test.md": bare },
+      customRules: [noBareUrls],
+      config: { default: false, "no-bare-url": true },
+      // No markdownItFactory — mirrors markdownlint-cli2 production usage
+    });
+    const errs = results["test.md"];
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs[0].ruleNames).toContain("BU001");
+  });
+
+  /**
+   * A proper [text](url) link must NOT be flagged.
+   */
+  test("does not flag a proper [text](url) markdown link", async () => {
+    const proper = "[Visit example](https://example.com)";
+    const results = await lint({
+      strings: { "test.md": proper },
+      customRules: [noBareUrls],
+      config: { default: false, "no-bare-url": true },
+    });
+    expect(results["test.md"].length).toBe(0);
+  });
+
+  /**
+   * allowedDomains config skips flagging for the listed domain.
+   */
+  test("respects allowedDomains configuration", async () => {
+    const allowed = "See https://internal.corp/docs for details.";
+    const results = await lint({
+      strings: { "test.md": allowed },
+      customRules: [noBareUrls],
+      config: {
+        default: false,
+        "no-bare-url": { allowedDomains: ["internal.corp"] },
+      },
+    });
+    expect(results["test.md"].length).toBe(0);
+  });
+
+  /**
+   * A standalone bare URL on its own line must be reported.
+   */
+  test("reports a standalone bare URL on its own line", async () => {
+    const standalone = "https://standalone.example.com";
+    const results = await lint({
+      strings: { "test.md": standalone },
+      customRules: [noBareUrls],
+      config: { default: false, "no-bare-url": true },
+    });
+    const errs = results["test.md"];
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs[0].ruleNames).toContain("BU001");
+  });
+
+  /**
    * Test specific autofix scenarios
    */
   test("correctly formats autofix for different URL patterns", async () => {
@@ -98,7 +159,6 @@ describe("no-bare-urls-trap rule", () => {
           default: false,
           "no-bare-url": true,
         },
-        markdownItFactory: () => new MarkdownIt({ linkify: true }),
       };
       
       const results = await lint(options);

--- a/tests/fixtures/no-bare-urls.fixture.md
+++ b/tests/fixtures/no-bare-urls.fixture.md
@@ -54,7 +54,7 @@ A URL used as link text is also fine: http://api.example.com. <!-- ❌ -->
 
 ### Non-URLs
 
-This is not a URL: my.domain.com/file.txt <!-- ❌ fix: This is not a URL: link. -->
+This is not a URL: my.domain.com/file.txt <!-- ✅ -->
 
 ## Invalid cases (should trigger the rule)
 

--- a/tests/helpers/fixture-validator.js
+++ b/tests/helpers/fixture-validator.js
@@ -6,7 +6,6 @@
  */
 
 import { lint } from 'markdownlint/promise';
-import MarkdownIt from 'markdown-it';
 
 /**
  * Parse fixture content to extract line expectations
@@ -126,12 +125,11 @@ export async function testRuleWithFixtureValidation(rule, content, ruleName, opt
   // Parse expectations from fixture
   const expectations = parseFixtureExpectations(content);
   
-  // Default lint options with markdown-it support
+  // Default lint options
   const lintOptions = {
     customRules: [rule],
     strings: { content },
     resultVersion: 3,
-    markdownItFactory: () => new MarkdownIt({ linkify: true }),
     ...options
   };
   


### PR DESCRIPTION
## Summary

- Rewrites `no-bare-url` / BU001 to detect bare URLs by scanning raw text lines with a URL regex instead of relying on markdown-it's `linkify` option
- Adds `parser: "none"` to the rule so markdownlint does not require `markdownItFactory`, mirroring real markdownlint-cli2 consumption
- Fixes config reading: `params.config` is already rule-scoped by markdownlint; removes the incorrect double-nesting lookup
- Updates tests to run without `linkify: true` and adds explicit regression cases

Closes #307

## Test plan

### Automated testing
- [x] New regression test: bare URL in prose fires BU001 without `markdownItFactory` (the production path)
- [x] New unit cases: standalone URL, `allowedDomains` skip, proper `[text](url)` not flagged
- [x] Fixture updated: `my.domain.com/file.txt` (no protocol) correctly marked ✅
- [x] `linkify: true` removed from `fixture-validator.js` helper and all bare-url tests
- [x] Full suite: 1722 tests pass, 0 failures

### Manual testing
- [x] Verified `<url>` autolinks are not flagged
- [x] Verified inline code `` `http://url` `` not flagged
- [x] Verified fenced code blocks not flagged
- [x] Verified reference link definitions `[1]: url` not flagged
- [x] Verified `[text](url)` inline links not flagged

## Breaking changes

None — the rule now fires where it was previously inert.