### PR TITLE
Guard that line-length stays disabled in all presets

### DIFF
--- a/tests/unit/preset-line-length.test.js
+++ b/tests/unit/preset-line-length.test.js
@@ -1,0 +1,25 @@
+/**
+ * @unit
+ * Guards that line-length enforcement (MD013) stays disabled in every shipped
+ * preset. Hard-wrapping prose at a fixed column produces noisy diffs and merge
+ * conflicts under version control, and on first adoption MD013 drowned out the
+ * styleguide's high-signal custom rules (see issue #299). The presets disable
+ * it universally; this test prevents a regression that re-enables it.
+ */
+import { describe, test, expect } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import * as jsonc from 'jsonc-parser';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const PRESETS = ['basic-config.jsonc', 'recommended-config.jsonc', 'strict-config.jsonc'];
+
+describe('Preset line-length (MD013) policy', () => {
+  test.each(PRESETS)('%s disables MD013', (preset) => {
+    const text = readFileSync(join(repoRoot, preset), 'utf8');
+    const parsed = jsonc.parse(text, undefined, { allowTrailingComma: true });
+    expect(parsed.config.MD013).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Issue #299 asked to disable line-length (MD013) by default. Investigation found MD013 is **already** `false` in all three presets (`basic`, `recommended`, `strict`) and the VS Code templates — and has been since the presets were first authored. The CLI `mdsg init` templates inherit it via `extends`, so consumers already get line-length off.
- The v4.0.4 report predates this state (or used a non-preset config). No behavior change is needed; per maintainer direction, line-length is off in **all** presets.
- This PR adds a regression guard so a future edit can't silently re-enable MD013 in any preset.

Closes #299

## Test plan

- [x] Unit test asserts `MD013 === false` for all three preset configs
- [x] Full suite + lint pass

## Breaking changes

None — no runtime behavior change.