### PR TITLE
Exempt bold definition-list labels from sentence-case first-word check

### DIFF
--- a/src/rules/sentence-case-heading.js
+++ b/src/rules/sentence-case-heading.js
@@ -379,12 +379,13 @@ function basicSentenceCaseHeadingFunction(params, onError) {
 
       // Detect whether this bold span is a definition-list label: the text
       // immediately after `**label**` in the source line opens with an em dash
-      // (—) or en dash (–). Colon is deliberately excluded — existing tests
-      // validate colon-separated bold labels as prose, and the colon split
-      // below already scopes those. Definition labels are code field names,
-      // CLI flags, or identifiers whose casing must be preserved — only the
-      // first-word check is suppressed; subsequent-word casing errors are still
-      // reported (issue #297, Problem 2).
+      // (—) or en dash (–). The colon-after-bold form (`**foo**: desc`) is
+      // intentionally left for a follow-up — existing tests validate those as
+      // prose. (The colon split below is unrelated: it scopes only an inline
+      // colon *inside* the bold markers, e.g. `**foo: bar**`.) Definition
+      // labels are code field names, CLI flags, or identifiers whose casing
+      // must be preserved — only the first-word check is suppressed;
+      // subsequent-word casing errors are still reported (issue #297, Problem 2).
       const textAfterBold = line.slice(matchEnd);
       const isDefinitionLabel = /^\s*(—|–)/.test(textAfterBold);
 

--- a/src/rules/sentence-case-heading.js
+++ b/src/rules/sentence-case-heading.js
@@ -234,8 +234,10 @@ function basicSentenceCaseHeadingFunction(params, onError) {
    * @param {number} lineNumber The line number of the text.
    * @param {string} sourceLine The full source line.
    * @param {number} [matchStart=0] Offset of the bold span within sourceLine.
+   * @param {boolean} [isDefinitionLabel=false] True when the bold span is immediately
+   *   followed by a definition separator; suppresses the first-word capitalization check.
    */
-  function validateBoldTextInContext(boldText, lineNumber, sourceLine, matchStart = 0) {
+  function validateBoldTextInContext(boldText, lineNumber, sourceLine, matchStart = 0, isDefinitionLabel = false) {
     if (!boldText || !boldText.trim()) {
       return;
     }
@@ -248,7 +250,7 @@ function basicSentenceCaseHeadingFunction(params, onError) {
     // Apply ignoreAfterEmoji truncation if enabled
     const { textForValidation } = truncateAtEmoji(boldText, ignoreAfterEmoji);
 
-    const validationResult = validateBoldText(textForValidation, specialCasedTerms, effectiveAmbiguousTerms);
+    const validationResult = validateBoldText(textForValidation, specialCasedTerms, effectiveAmbiguousTerms, { skipFirstWord: isDefinitionLabel });
 
     if (!validationResult.isValid) {
       reportForBoldText(validationResult.errorMessage, lineNumber, boldText, sourceLine, textForValidation, matchStart);
@@ -375,6 +377,14 @@ function basicSentenceCaseHeadingFunction(params, onError) {
       const boldText = match[1].trim();
       if (!boldText) continue;
 
+      // Detect whether this bold span is a definition-list label: the text
+      // immediately after `**label**` in the source line is a definition
+      // separator (em dash, en dash, hyphen-with-spaces, or colon + space).
+      // Definition labels are code field names, CLI flags, or identifiers
+      // whose casing must be preserved — only the first-word check is suppressed;
+      // subsequent-word casing errors are still reported (issue #297, Problem 2).
+      const textAfterBold = line.slice(matchEnd);
+      const isDefinitionLabel = /^\s*(—|–)/.test(textAfterBold);
 
       // If the bold text has a colon, only validate the part before the colon
       const textToValidate = boldText.includes(':') ?
@@ -386,7 +396,7 @@ function basicSentenceCaseHeadingFunction(params, onError) {
 
       // Use the unified validation logic; pass the span offset so the autofix
       // targets this occurrence even if the same bold phrase repeats on the line.
-      validateBoldTextInContext(textToValidate, lineNumber, line, matchStart);
+      validateBoldTextInContext(textToValidate, lineNumber, line, matchStart, isDefinitionLabel);
 
       // Only validate the first bold text in the list item (which we already confirmed is at the start)
       break;

--- a/src/rules/sentence-case-heading.js
+++ b/src/rules/sentence-case-heading.js
@@ -378,11 +378,13 @@ function basicSentenceCaseHeadingFunction(params, onError) {
       if (!boldText) continue;
 
       // Detect whether this bold span is a definition-list label: the text
-      // immediately after `**label**` in the source line is a definition
-      // separator (em dash, en dash, hyphen-with-spaces, or colon + space).
-      // Definition labels are code field names, CLI flags, or identifiers
-      // whose casing must be preserved — only the first-word check is suppressed;
-      // subsequent-word casing errors are still reported (issue #297, Problem 2).
+      // immediately after `**label**` in the source line opens with an em dash
+      // (—) or en dash (–). Colon is deliberately excluded — existing tests
+      // validate colon-separated bold labels as prose, and the colon split
+      // below already scopes those. Definition labels are code field names,
+      // CLI flags, or identifiers whose casing must be preserved — only the
+      // first-word check is suppressed; subsequent-word casing errors are still
+      // reported (issue #297, Problem 2).
       const textAfterBold = line.slice(matchEnd);
       const isDefinitionLabel = /^\s*(—|–)/.test(textAfterBold);
 

--- a/src/rules/sentence-case/bold-text-classifier.js
+++ b/src/rules/sentence-case/bold-text-classifier.js
@@ -26,9 +26,10 @@ import {
  * @param {boolean} hadLeadingEmoji Whether the original text had leading emoji.
  * @param {Object} specialCasedTerms Special casing terms.
  * @param {Object} ambiguousTerms Ambiguous terms to skip (optional).
+ * @param {{skipFirstWord?: boolean}} [options] Extra validation options.
  * @returns {{isValid: boolean, errorMessage?: string}} Validation result.
  */
-export function performBoldTextValidation(words, cleanedText, hadLeadingEmoji, specialCasedTerms, ambiguousTerms = {}) {
+export function performBoldTextValidation(words, cleanedText, hadLeadingEmoji, specialCasedTerms, ambiguousTerms = {}, options = {}) {
   const firstIndex = findFirstValidationWord(words);
   if (firstIndex === -1) {
     return { isValid: true };
@@ -40,9 +41,11 @@ export function performBoldTextValidation(words, cleanedText, hadLeadingEmoji, s
   // Check if the original text starts with a number
   const startsWithNumber = firstIndex > 0 && /^\d/.test(words[0]);
 
-  // Validate first word (but not if it comes after a number in bold text)
+  // Validate first word (but not if it comes after a number in bold text, or if
+  // the caller signals this is a definition-list label whose identifier casing must
+  // not be altered — issue #297, Problem 2).
   const firstWord = words[firstIndex];
-  if (!startsWithNumber) {
+  if (!startsWithNumber && !options.skipFirstWord) {
     const firstWordResult = validateFirstWord(firstWord, firstIndex, phraseIgnore, specialCasedTerms, cleanedText, hadLeadingEmoji, ambiguousTerms);
     if (!firstWordResult.isValid) {
       return firstWordResult;
@@ -219,9 +222,10 @@ export function performBoldTextValidation(words, cleanedText, hadLeadingEmoji, s
  * @param {string} boldText The bold text to validate.
  * @param {Object} specialCasedTerms Special casing terms dictionary.
  * @param {Object} ambiguousTerms Ambiguous terms to skip (optional).
+ * @param {{skipFirstWord?: boolean}} [options] Extra validation options.
  * @returns {{isValid: boolean, errorMessage?: string}} Validation result.
  */
-export function validateBoldText(boldText, specialCasedTerms, ambiguousTerms = {}) {
+export function validateBoldText(boldText, specialCasedTerms, ambiguousTerms = {}, options = {}) {
   if (!boldText || !boldText.trim()) {
     return { isValid: true };
   }
@@ -308,5 +312,5 @@ export function validateBoldText(boldText, specialCasedTerms, ambiguousTerms = {
   }
 
   // For bold text, use stricter validation
-  return performBoldTextValidation(processedWords, cleanedText, hadLeadingEmoji, specialCasedTerms, ambiguousTerms);
+  return performBoldTextValidation(processedWords, cleanedText, hadLeadingEmoji, specialCasedTerms, ambiguousTerms, options);
 }

--- a/tests/fixtures/sentence-case/heading/list-items-bold.md
+++ b/tests/fixtures/sentence-case/heading/list-items-bold.md
@@ -36,4 +36,5 @@
 - **url** — the request URL <!-- ✅ -->
 - **bar** — another field <!-- ✅ -->
 - **baz** – en dash definition <!-- ✅ -->
+- **This Is Title Case** — desc <!-- ❌ -->
 - **this is prose** and more text <!-- ❌ -->

--- a/tests/fixtures/sentence-case/heading/list-items-bold.md
+++ b/tests/fixtures/sentence-case/heading/list-items-bold.md
@@ -30,3 +30,10 @@
 - **This is a test with _BOLD_** <!-- ❌ -->
 - **This is a test with 2023-10-26 Date** <!-- ❌ -->
 - **This is a test with V1.0.0 Version** <!-- ❌ -->
+
+<!-- Definition-list label exemptions (issue #297, Problem 2) -->
+- **foo** — a short description <!-- ✅ -->
+- **url** — the request URL <!-- ✅ -->
+- **bar** — another field <!-- ✅ -->
+- **baz** – en dash definition <!-- ✅ -->
+- **this is prose** and more text <!-- ❌ -->

--- a/tests/unit/sentence-case-classifier.test.js
+++ b/tests/unit/sentence-case-classifier.test.js
@@ -747,3 +747,24 @@ describe("validateBoldText — #303 parenthesized multi-word proper nouns", () =
     expect(result.isValid).toBe(false);
   });
 });
+
+describe("validateHeading — #297 multi-word specialTerms in headings", () => {
+  // Problem 1 (resolved by #303): multi-word specialTerms phrase matching in heading path.
+  // Verified here as a regression guard so this fix is not silently reverted.
+  const termsAcme = { "acme widgets": "Acme Widgets" };
+
+  test("heading with configured multi-word term does not flag second word (#297/#303)", () => {
+    const result = validateHeading("Process Acme Widgets", termsAcme);
+    expect(result.isValid).toBe(true);
+  });
+
+  test("numbered heading with configured multi-word term does not flag term words (#297/#303)", () => {
+    const result = validateHeading("6. Process Acme Widgets", termsAcme);
+    expect(result.isValid).toBe(true);
+  });
+
+  test("unconfigured capitalized word in heading is still flagged (regression guard)", () => {
+    const result = validateHeading("Process Foo Bar", {});
+    expect(result.isValid).toBe(false);
+  });
+});

--- a/tests/unit/sentence-case-classifier.test.js
+++ b/tests/unit/sentence-case-classifier.test.js
@@ -768,3 +768,23 @@ describe("validateHeading — #297 multi-word specialTerms in headings", () => {
     expect(result.isValid).toBe(false);
   });
 });
+
+describe("validateBoldText — #297 definition-label skipFirstWord invariant", () => {
+  // skipFirstWord exempts ONLY the first word's casing (identifier labels like
+  // `url`/`foo`); subsequent-word casing checks must still fire so a genuinely
+  // mis-cased multi-word label is not silently exempted.
+  test("skipFirstWord exempts a lowercase identifier first word", () => {
+    const result = validateBoldText("url", {}, {}, { skipFirstWord: true });
+    expect(result.isValid).toBe(true);
+  });
+
+  test("subsequent-word casing is still flagged under skipFirstWord", () => {
+    const result = validateBoldText(
+      "This Is Title Case",
+      {},
+      {},
+      { skipFirstWord: true },
+    );
+    expect(result.isValid).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes SC001 false positives where bold list-item labels used as definition-list terms (e.g. `- **foo** — description`, `- **url** — the address`) were incorrectly flagged for first-word capitalization
- Adds `skipFirstWord` option to `validateBoldText`/`performBoldTextValidation` so callers can suppress first-word capitalization without disabling subsequent-word checks
- Adds regression tests for multi-word `specialTerms`/`properNouns` phrase matching in headings

Closes #297

## Problem 1 disposition

**Already resolved by #303.** The `normalizeToken` helper added in that fix makes `getProperPhraseIndices` correctly strip surrounding punctuation before matching, which applies to both the heading and bold-text paths. Verified: `## Process Acme Widgets` with `specialTerms: ["Acme Widgets"]` returns no SC001 error. Regression tests added to `sentence-case-classifier.test.js`.

## Problem 2 disposition

**Fixed in this PR.** When a bold list-item label is immediately followed by an em dash (`—`) or en dash (`–`) in the source line, the first-word capitalization/acronym-casing check is suppressed. Subsequent-word casing errors are still reported, so `- **This Is Title Case** — desc` still correctly flags `Is`. The detection regex is conservative (em/en dash only) to avoid conflicts with existing tests that validate colon-separated patterns.

## Test plan

### Automated testing
- [x] Unit tests pass (`npm test`)
- [x] Integration tests pass
- [x] Full test suite passes (1755 passing, 9 pre-existing skips)
- [x] ESLint clean (`npm run lint`)

### New test coverage
- [x] `tests/fixtures/sentence-case/heading/list-items-bold.md` — four new passing lines for definition-label patterns, one failing line for prose without separator
- [x] `tests/unit/sentence-case-classifier.test.js` — three regression tests for multi-word specialTerms in headings

## Breaking changes

None — backward compatible. Adds a new `options` parameter with a default of `{}` to two internal functions.