### PR TITLE
Exempt colon-separated identifier definition labels from SC001 first-word check

### DIFF
--- a/src/rules/sentence-case-heading.js
+++ b/src/rules/sentence-case-heading.js
@@ -42,6 +42,7 @@ import { buildLineContext } from './shared-context.js';
 import { extractHeadingText } from './sentence-case/token-extraction.js';
 import { validateHeading } from './sentence-case/case-classifier.js';
 import { validateBoldText } from './sentence-case/bold-text-classifier.js';
+import { isCodeIdentifier } from './sentence-case/word-validators.js';
 import { toSentenceCase, buildHeadingFix, buildBoldTextFix } from './sentence-case/fix-builder.js';
 import debug from '../logger.js';
 
@@ -55,6 +56,31 @@ const _deprecationWarned = new Set();
  * @type {Map<string, Record<string, string>>}
  */
 const _specialCasedTermsCache = new Map();
+
+/**
+ * Determines whether a bold list-item label reads as a code identifier rather
+ * than prose. A colon-separated definition label (`**url**: the address`) skips
+ * the first-word capitalization check only when the label is identifier-shaped,
+ * so Title-Case prose labels (`**This Is Title Case**:`) stay sentence-case
+ * checked. The label must be a single token that is either lowercase-leading
+ * (`url`, `foo`, `--flag`, `node.js`) or a camelCase/PascalCase/snake_case code
+ * identifier (issue #317). The em/en-dash form is unconditional and does not
+ * pass through this gate.
+ * @param {string} label The bold label text (before any inline colon).
+ * @returns {boolean} True when the label is an identifier-style definition label.
+ */
+function isIdentifierDefinitionLabel(label) {
+  const token = label.trim();
+  if (!token || /\s/.test(token)) {
+    return false;
+  }
+  // Lowercase-leading single tokens read as identifiers, CLI flags, or paths.
+  if (/^[a-z`_$./-]/.test(token)) {
+    return true;
+  }
+  // camelCase / PascalCase / snake_case code identifiers (e.g. HttpClient).
+  return isCodeIdentifier(token);
+}
 
 /**
  * Main rule implementation.
@@ -377,25 +403,27 @@ function basicSentenceCaseHeadingFunction(params, onError) {
       const boldText = match[1].trim();
       if (!boldText) continue;
 
-      // Detect whether this bold span is a definition-list label: the text
-      // immediately after `**label**` in the source line opens with an em dash
-      // (—) or en dash (–). The colon-after-bold form (`**foo**: desc`) is
-      // intentionally left for a follow-up — existing tests validate those as
-      // prose. (The colon split below is unrelated: it scopes only an inline
-      // colon *inside* the bold markers, e.g. `**foo: bar**`.) Definition
-      // labels are code field names, CLI flags, or identifiers whose casing
-      // must be preserved — only the first-word check is suppressed;
-      // subsequent-word casing errors are still reported (issue #297, Problem 2).
-      const textAfterBold = line.slice(matchEnd);
-      const isDefinitionLabel = /^\s*(—|–)/.test(textAfterBold);
-
       // If the bold text has a colon, only validate the part before the colon
+      // (this scopes an inline colon *inside* the bold markers, e.g. `**foo: bar**`).
       const textToValidate = boldText.includes(':') ?
         boldText.split(':')[0].trim() :
         boldText;
 
       // Skip empty text
       if (!textToValidate) continue;
+
+      // Detect whether this bold span is a definition-list label: the text
+      // immediately after `**label**` in the source line opens with a definition
+      // separator. Em/en dash (—, –) always qualifies. A colon qualifies only
+      // when the label is identifier-shaped (`**url**: ...`), so Title-Case
+      // prose labels (`**This Is Title Case**:`) stay sentence-case checked.
+      // Definition labels are code field names, CLI flags, or identifiers whose
+      // casing must be preserved — only the first-word check is suppressed;
+      // subsequent-word casing errors are still reported (issues #297, #317).
+      const textAfterBold = line.slice(matchEnd);
+      const isDefinitionLabel =
+        /^\s*(—|–)/.test(textAfterBold) ||
+        (/^\s*:/.test(textAfterBold) && isIdentifierDefinitionLabel(textToValidate));
 
       // Use the unified validation logic; pass the span offset so the autofix
       // targets this occurrence even if the same bold phrase repeats on the line.

--- a/tests/fixtures/sentence-case/heading/list-items-bold.md
+++ b/tests/fixtures/sentence-case/heading/list-items-bold.md
@@ -44,5 +44,7 @@
 - **foo**: a field <!-- ✅ -->
 - **myVar**: a camelCase identifier <!-- ✅ -->
 - **--flag**: a CLI flag <!-- ✅ -->
+- **note**: a plain lowercase word reads as an identifier label <!-- ✅ -->
 - **This Is Title Case**: desc <!-- ❌ -->
 - **This is prose Label**: with text <!-- ❌ -->
+- **Json**: a single Title-case token is still first-word checked <!-- ❌ -->

--- a/tests/fixtures/sentence-case/heading/list-items-bold.md
+++ b/tests/fixtures/sentence-case/heading/list-items-bold.md
@@ -38,3 +38,11 @@
 - **baz** – en dash definition <!-- ✅ -->
 - **This Is Title Case** — desc <!-- ❌ -->
 - **this is prose** and more text <!-- ❌ -->
+
+<!-- Colon-separated identifier definition labels (issue #317) -->
+- **url**: the address <!-- ✅ -->
+- **foo**: a field <!-- ✅ -->
+- **myVar**: a camelCase identifier <!-- ✅ -->
+- **--flag**: a CLI flag <!-- ✅ -->
+- **This Is Title Case**: desc <!-- ❌ -->
+- **This is prose Label**: with text <!-- ❌ -->


### PR DESCRIPTION
## Summary

- Extend the SC001 definition-label exemption to colon-separated labels, completing the follow-up deferred from #297 (the em/en-dash form was fixed in #316).
- A bold list-item label followed by a colon (`- **url**: the address`) now skips the first-word capitalization check, but only when the label is identifier-shaped — a single token that is lowercase-leading (`url`, `foo`, `--flag`, `node.js`) or a camelCase/PascalCase/snake_case code identifier.
- Title-Case prose colon labels (`- **This Is Title Case**: desc`) stay sentence-case checked, so subsequent-word casing is still flagged. This mirrors the existing em/en-dash handling and avoids regressing the prose colon-label fixtures.

Closes #317

## Test plan

### Automated testing
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Full test suite passes (`npm test` — 1767 passed)

### Manual testing
- [x] Verified all four acceptance-criteria strings end-to-end via `markdownlint/promise`: `**url**:` and `**foo**:` not flagged; `**This is a correct item**:` passes as valid prose; `**This Is Title Case**:` flags `Is`.
- [x] `npm run lint` (ESLint) and `npm run lint:md` (markdownlint) clean

### Test coverage
- [x] New functionality has tests (fixture cases in `tests/fixtures/sentence-case/heading/list-items-bold.md`, exercised by the list-items-bold feature test)
- [x] Tests follow behavioral naming

## Breaking changes

None — backward compatible. The change only suppresses a first-word false positive for identifier colon-labels; prose labels are unaffected.

## Documentation

- [x] Docstrings added for new public functions (JSDoc on `isIdentifierDefinitionLabel`)
- [ ] API documentation updated if public APIs added or changed — no public API surface changed *(optional)*
- [ ] README updated if public-facing behavior changed — internal rule heuristic only *(optional)*
