### PR TITLE
Stop BCE001 flagging prose phrases as code elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ User-facing changes — new capabilities, behavior changes, fixes that affected 
 
 ## [Unreleased]
 
+### Fixed
+
+- BCE001 no longer flags prose uses of "import" as a noun or attributive
+  modifier — "Instagram import polish", "the import success screen", "import
+  safety fixes" — while genuine statements like `import Foundation` and
+  `import pdfplumber` still fire. The common-word exclusion list moved out of
+  the regex into a maintainable set, and noun usage is now also detected from
+  context (a preceding determiner or mid-sentence proper noun). (#319)
+- BCE001 no longer treats prose slash-lists with short or hyphenated segments
+  — "grades/stars/half-stars", "title/id/year",
+  "auto-renewal/cancellation/refund" — as file paths. Placeholder paths like
+  `path/to/folder` and paths with extensions are still flagged. (#319)
+
 ---
 
 ## [4.1.0] - 2026-06-30

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -4,6 +4,8 @@ Engineering record — refactors, internal tooling, build changes, ADRs, depende
 
 ## [Unreleased]
 
+- Replaced the BCE001 import exclusion regex — a ~100-alternative negative lookahead — with named `Set`s in `detection-helpers.js` (`importProseObjects` plus determiner, positional, and language-name signal sets), with the prose-vs-statement decision order documented on the new `isProseImportUsage` helper
+
 ---
 
 ## [4.1.0] - 2026-06-30

--- a/src/rules/backtick-code-elements.js
+++ b/src/rules/backtick-code-elements.js
@@ -27,7 +27,8 @@ import {
   inWikiLink,
   inHtmlSemanticTag,
   inLatexMath,
-  isLikelyFilePath
+  isLikelyFilePath,
+  isProseImportUsage
 } from './backtick/detection-helpers.js';
 import { generateContextualErrorMessage } from './backtick/error-messages.js';
 
@@ -166,11 +167,10 @@ function backtickCodeElements(params, onError) {
       /\b(?:cargo)\s+(?:build|run|test|bench|check|clean|doc|new|init|add|remove|update|publish|install|uninstall|search|tree|fmt|clippy)\b/g,
 
                                              // common CLI commands
-      // import statements - exclude common English words after "import"
-      // This catches "import pdfplumber" but not "import them", "import system", etc.
-      // Exclusion list covers pronouns, articles, prepositions, and common nouns
-      // Each alternative uses \b to prevent prefix-matching (e.g., "to" blocking "tokenizer")
-      /\bimport\s+(?!(?:the|a|an|your|my|our|their|its|some|all|any|this|that|these|those|from|into|in|on|with|without|for|via|using|under|over|to|new|old|more|them|it|something|everything|anything|nothing|system|systems|updates|path|paths|is|are|was|were|will|be|data|files|modules|packages|settings|config|options|rules|code|process|other|changes|and|or|statements|functions|classes|types|errors|values|items|records|content|text|names|custom|external|internal|local|global|default|specific|relevant|existing|additional|required|necessary|important|direct|proper|tool|tools|image|images|photo|photos|video|videos|asset|assets|document|documents|record|records|entry|entries|contact|contacts|user|users|product|products|order|orders|transaction|transactions|customer|customers|book|books|song|songs|track|tracks|recipe|recipes|template|templates|model|models)\b)\w+/g,
+      // import statements - prose usages ("Instagram import polish",
+      // "the import success screen") are filtered by isProseImportUsage,
+      // which holds the common-English-word exclusion list (#319)
+      /\bimport\s+\w+/g,
       // host:port patterns, avoids bible verses like "1:10" and WCAG ratios like "4.5:1"
       // Time ranges like "AM-12:30", "3-10:30" are filtered out separately
       // Negative lookbehind: not preceded by decimal number (WCAG ratios)
@@ -272,6 +272,13 @@ function backtickCodeElements(params, onError) {
         // (contain / as a literal match, not in a negative lookahead)
         const isPathPattern = pattern.source.includes('\\/') && !pattern.source.includes('(?!');
         if (isPathPattern && !isLikelyFilePath(fullMatch)) {
+          continue;
+        }
+
+        // Skip prose uses of "import" as a noun or attributive modifier
+        // ("Instagram import polish", "the import success screen") while
+        // keeping genuine statements like "import Foundation" flagged (#319).
+        if (/^import\s/.test(fullMatch) && isProseImportUsage(line, start, fullMatch)) {
           continue;
         }
 

--- a/src/rules/backtick/detection-helpers.js
+++ b/src/rules/backtick/detection-helpers.js
@@ -82,11 +82,27 @@ const importPositionalSignals = new Set([
 
 // Language names preceding "import" introduce a real statement ("For Python
 // import pdfplumber", "In Swift import Foundation"), unlike attributive
-// proper nouns ("the Salesforce import connector").
+// proper nouns ("the Salesforce import connector"). Only applied when the
+// language name is clause-initial or follows a preposition — after a verb
+// ("Improved Python import resolution") it is attributive prose.
 const importLanguageNames = new Set([
   'Python', 'Swift', 'JavaScript', 'TypeScript', 'Java', 'Kotlin', 'Rust',
   'Go', 'Ruby', 'PHP', 'Haskell', 'Scala', 'Perl', 'Julia', 'Dart',
   'Elixir', 'Lua', 'Clojure', 'Node'
+]);
+
+// Prepositions that put a following language name in statement-introducing
+// position ("For Python import X", "In Swift import Y").
+const importLanguagePrepositions = new Set([
+  'for', 'in', 'with', 'on', 'to', 'under', 'via', 'using', 'from'
+]);
+
+// Determiners and pronouns that can never be a module name in a Python-style
+// `from X import Y` clause — "from the import screen" is English, not code.
+const importFromDeterminers = new Set([
+  'the', 'a', 'an', 'your', 'my', 'our', 'their', 'its', 'his', 'her',
+  'this', 'that', 'these', 'those', 'each', 'every', 'any', 'some',
+  'no', 'one', 'another'
 ]);
 
 /**
@@ -107,8 +123,9 @@ const importLanguageNames = new Set([
  *    import pdfplumber") and sentence-initial verbs ("Add import
  *    pdfplumber") keep firing.
  *
- * A `from X import Y` clause always counts as a real statement, whatever
- * the object word.
+ * A `from X import Y` clause counts as a real statement whatever the
+ * object word — unless X is a determiner or pronoun ("from the import
+ * screen"), which is always English prose.
  *
  * @param {string} line - Line being evaluated.
  * @param {number} start - Start index of the `import …` match.
@@ -119,8 +136,10 @@ export function isProseImportUsage(line, start, match) {
   const beforeImport = line.slice(0, start);
 
   // "from sklearn import pipeline" is a Python statement regardless of how
-  // English the imported name looks.
-  if (/\bfrom\s+[\w.]+\s+$/.test(beforeImport)) {
+  // English the imported name looks — but "from the import screen" is prose
+  // (no module is named "the"); let those fall through to the noun checks.
+  const fromClauseMatch = /\bfrom\s+([\w.]+)\s+$/.exec(beforeImport);
+  if (fromClauseMatch && !importFromDeterminers.has(fromClauseMatch[1].toLowerCase())) {
     return false;
   }
 
@@ -154,7 +173,16 @@ export function isProseImportUsage(line, start, match) {
 
   if (/^[A-Z]/.test(precedingWord)) {
     if (importLanguageNames.has(precedingWord)) {
-      return false;
+      // "For Python import pdfplumber" introduces a statement; "Improved
+      // Python import resolution" uses the language name attributively.
+      const wordBeforeLanguage = /([A-Za-z][\w'’-]*)[*_]{0,3}\s+$/.exec(beforeWord);
+      if (
+        wordIsSentenceInitial ||
+        (wordBeforeLanguage &&
+          importLanguagePrepositions.has(wordBeforeLanguage[1].toLowerCase()))
+      ) {
+        return false;
+      }
     }
     if (!wordIsSentenceInitial) {
       return true;

--- a/src/rules/backtick/detection-helpers.js
+++ b/src/rules/backtick/detection-helpers.js
@@ -132,6 +132,10 @@ const importFromDeterminers = new Set([
  * @param {string} match - The matched text (e.g., "import polish").
  * @returns {boolean} True when the match is prose, not a code statement.
  */
+// Captures the word preceding the end of a text slice, skipping trailing
+// emphasis markers so "**Bulk** " still exposes "Bulk".
+const precedingWordPattern = /([A-Za-z][\w'’-]*)[*_]{0,3}\s+$/;
+
 export function isProseImportUsage(line, start, match) {
   const beforeImport = line.slice(0, start);
 
@@ -148,9 +152,7 @@ export function isProseImportUsage(line, start, match) {
     return true;
   }
 
-  // Trailing emphasis markers are skipped so "**Bulk** import parser"
-  // still exposes the "bulk" signal.
-  const precedingWordMatch = /([A-Za-z][\w'’-]*)[*_]{0,3}\s+$/.exec(beforeImport);
+  const precedingWordMatch = precedingWordPattern.exec(beforeImport);
   if (!precedingWordMatch) {
     return false;
   }
@@ -175,7 +177,7 @@ export function isProseImportUsage(line, start, match) {
     if (importLanguageNames.has(precedingWord)) {
       // "For Python import pdfplumber" introduces a statement; "Improved
       // Python import resolution" uses the language name attributively.
-      const wordBeforeLanguage = /([A-Za-z][\w'’-]*)[*_]{0,3}\s+$/.exec(beforeWord);
+      const wordBeforeLanguage = precedingWordPattern.exec(beforeWord);
       if (
         wordIsSentenceInitial ||
         (wordBeforeLanguage &&

--- a/src/rules/backtick/detection-helpers.js
+++ b/src/rules/backtick/detection-helpers.js
@@ -17,6 +17,112 @@ import {
 const linkRegex = /!?\[[^\]]*\]\([^)]*\)/g;
 const wikiLinkRegex = /!?\[\[[^\]]+\]\]/g;
 
+// Words that, when they follow "import", mark ordinary English prose rather
+// than a code import statement ("import them", "import success screen").
+// Formerly inlined as a giant negative lookahead in the import regex; moved
+// here so the list is maintainable and the check is testable (#319).
+// Matching is case-sensitive: capitalized tokens ("import Foundation",
+// "import System") keep firing as genuine module imports.
+const importProseObjects = new Set([
+  // Pronouns, articles, prepositions, conjunctions
+  'the', 'a', 'an', 'your', 'my', 'our', 'their', 'its', 'some', 'all',
+  'any', 'this', 'that', 'these', 'those', 'from', 'into', 'in', 'on',
+  'with', 'without', 'for', 'via', 'using', 'under', 'over', 'to',
+  'them', 'it', 'and', 'or', 'is', 'are', 'was', 'were', 'will', 'be',
+  // Quantifiers and generic modifiers
+  'new', 'old', 'more', 'something', 'everything', 'anything', 'nothing',
+  'other', 'custom', 'external', 'internal', 'local', 'global', 'default',
+  'specific', 'relevant', 'existing', 'additional', 'required', 'necessary',
+  'important', 'direct', 'proper',
+  // Common nouns that follow "import" used as a noun or verb in prose
+  'system', 'systems', 'updates', 'path', 'paths', 'data', 'files',
+  'modules', 'packages', 'settings', 'config', 'options', 'rules', 'code',
+  'process', 'changes', 'statements', 'functions', 'classes', 'types',
+  'errors', 'values', 'items', 'records', 'content', 'text', 'names',
+  'tool', 'tools', 'image', 'images', 'photo', 'photos', 'video', 'videos',
+  'asset', 'assets', 'document', 'documents', 'record', 'entry', 'entries',
+  'contact', 'contacts', 'user', 'users', 'product', 'products', 'order',
+  'orders', 'transaction', 'transactions', 'customer', 'customers', 'book',
+  'books', 'song', 'songs', 'track', 'tracks', 'recipe', 'recipes',
+  'template', 'templates', 'model', 'models',
+  // Attributive nouns common in changelogs and release notes (#319)
+  'polish', 'success', 'safety', 'quality', 'speed', 'performance',
+  'reliability', 'stability', 'progress', 'history', 'preview', 'screen',
+  'screens', 'flow', 'flows', 'button', 'buttons', 'wizard', 'dialog',
+  'dialogs', 'experience', 'support', 'handling', 'validation', 'behavior',
+  'behaviour', 'workflow', 'workflows', 'feature', 'features',
+  'functionality', 'improvements', 'fixes', 'logic', 'pipeline',
+  'pipelines', 'status', 'summary', 'report', 'reports', 'page', 'pages',
+  'view', 'views', 'tab', 'tabs', 'panel', 'banner', 'prompt', 'prompts',
+  'limit', 'limits', 'count', 'counts', 'failure', 'failures', 'warning',
+  'warnings', 'notification', 'notifications', 'retry', 'retries', 'job',
+  'jobs', 'task', 'tasks', 'session', 'sessions', 'step', 'steps'
+]);
+
+// Determiners and modifiers that mark the following "import" as a noun
+// ("the import wizard", "bulk import support"), never a code statement.
+const importNounSignals = new Set([
+  'the', 'a', 'an', 'this', 'that', 'these', 'those',
+  'my', 'your', 'our', 'their', 'its', 'his', 'her',
+  'each', 'every', 'any', 'some', 'another', 'no', 'one',
+  'bulk', 'mass', 'batch', 'data', 'manual', 'automatic', 'automated',
+  'nightly', 'daily', 'weekly', 'monthly', 'initial', 'full', 'partial',
+  'failed', 'successful', 'new', 'existing',
+  'first', 'second', 'last', 'next', 'previous'
+]);
+
+/**
+ * Decide whether a matched `import <word>` sequence is ordinary English
+ * prose ("Instagram import polish", "the import success screen") rather
+ * than a code import statement ("import Foundation").
+ *
+ * Signals treated as prose (#319):
+ * 1. The word after `import` is a common English word, not a plausible
+ *    module identifier.
+ * 2. `import` is preceded by a determiner or noun-marking modifier
+ *    ("the import …", "bulk import …").
+ * 3. `import` is preceded by a capitalized word that is not the start of
+ *    its sentence — a mid-sentence proper noun used attributively
+ *    ("…the Salesforce import connector"). Sentence-initial verbs like
+ *    "Add import pdfplumber" or "Use import os" keep firing.
+ *
+ * @param {string} line - Line being evaluated.
+ * @param {number} start - Start index of the `import …` match.
+ * @param {string} match - The matched text (e.g., "import polish").
+ * @returns {boolean} True when the match is prose, not a code statement.
+ */
+export function isProseImportUsage(line, start, match) {
+  const objectWord = match.replace(/^import\s+/, '');
+  if (importProseObjects.has(objectWord)) {
+    return true;
+  }
+
+  const beforeImport = line.slice(0, start);
+  const precedingWordMatch = /([A-Za-z][\w'’-]*)\s+$/.exec(beforeImport);
+  if (!precedingWordMatch) {
+    return false;
+  }
+
+  const precedingWord = precedingWordMatch[1];
+  if (importNounSignals.has(precedingWord.toLowerCase())) {
+    return true;
+  }
+
+  if (/^[A-Z]/.test(precedingWord)) {
+    const beforeWord = beforeImport.slice(0, precedingWordMatch.index);
+    // Sentence-initial: only whitespace/list markers before the word, or the
+    // word follows sentence-boundary punctuation.
+    const sentenceInitial =
+      /^\s*(?:(?:[-*+>]|\d+[.)])\s+)*$/.test(beforeWord) ||
+      /[.!?:;,]["')\]]*\s+$/.test(beforeWord);
+    if (!sentenceInitial) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 // Common sentence starters that indicate a sentence boundary, not a filename.
 const sentenceStarters = new Set([
   'The', 'A', 'An', 'This', 'That', 'These', 'Those',
@@ -373,11 +479,25 @@ export function isLikelyFilePath(str) {
     return false;
   }
 
-  // If all segments (3+) are pure alphabetic words (3+ chars) with no file extensions,
-  // and it's not an absolute or relative path, it's likely natural language
+  // If all segments (3+) are plain English word shapes with no file extensions,
+  // and nothing marks the string as a real path, it's likely natural language.
+  // A word shape is 2+ letters, optionally hyphen-joined ("half-stars",
+  // "auto-renewal"), so prose alternative lists like "grades/stars/half-stars"
+  // or "title/id/year" are not treated as paths (#319). Path signals that
+  // override the bail-out: an absolute/relative prefix, or a "to" placeholder
+  // segment ("path/to/folder"). A known-directory first segment deliberately
+  // does not override: prose enumerations like "models/views/controllers"
+  // start with directory-like words (see the passing fixture).
   const nonEmptySegments = segments.filter(s => s !== '');
   const isAbsoluteOrRelative = /^[/~.]/.test(str);
-  if (!isAbsoluteOrRelative && nonEmptySegments.length >= 3 && nonEmptySegments.every(s => /^[a-zA-Z]{3,}$/.test(s)) && !nonEmptySegments.some(s => /\.\w+$/.test(s))) {
+  const hasPlaceholderSegment = nonEmptySegments.includes('to');
+  if (
+    !isAbsoluteOrRelative &&
+    !hasPlaceholderSegment &&
+    nonEmptySegments.length >= 3 &&
+    nonEmptySegments.every(s => /^[a-zA-Z]{2,}(?:-[a-zA-Z]+)*$/.test(s)) &&
+    !nonEmptySegments.some(s => /\.\w+$/.test(s))
+  ) {
     return false;
   }
 

--- a/src/rules/backtick/detection-helpers.js
+++ b/src/rules/backtick/detection-helpers.js
@@ -45,7 +45,10 @@ const importProseObjects = new Set([
   'orders', 'transaction', 'transactions', 'customer', 'customers', 'book',
   'books', 'song', 'songs', 'track', 'tracks', 'recipe', 'recipes',
   'template', 'templates', 'model', 'models',
-  // Attributive nouns common in changelogs and release notes (#319)
+  // Attributive nouns common in changelogs and release notes (#319).
+  // Real module names must stay OUT of this list: 'warnings' (Python
+  // stdlib), 'views'/'tasks' (Django/Celery), and 'retry' (PyPI) are
+  // deliberately absent so bare statements like "import warnings" fire.
   'polish', 'success', 'safety', 'quality', 'speed', 'performance',
   'reliability', 'stability', 'progress', 'history', 'preview', 'screen',
   'screens', 'flow', 'flows', 'button', 'buttons', 'wizard', 'dialog',
@@ -53,10 +56,10 @@ const importProseObjects = new Set([
   'behaviour', 'workflow', 'workflows', 'feature', 'features',
   'functionality', 'improvements', 'fixes', 'logic', 'pipeline',
   'pipelines', 'status', 'summary', 'report', 'reports', 'page', 'pages',
-  'view', 'views', 'tab', 'tabs', 'panel', 'banner', 'prompt', 'prompts',
+  'view', 'tab', 'tabs', 'panel', 'banner', 'prompt', 'prompts',
   'limit', 'limits', 'count', 'counts', 'failure', 'failures', 'warning',
-  'warnings', 'notification', 'notifications', 'retry', 'retries', 'job',
-  'jobs', 'task', 'tasks', 'session', 'sessions', 'step', 'steps'
+  'notification', 'notifications', 'retries', 'job',
+  'jobs', 'task', 'session', 'sessions', 'step', 'steps'
 ]);
 
 // Determiners and modifiers that mark the following "import" as a noun
@@ -67,8 +70,23 @@ const importNounSignals = new Set([
   'each', 'every', 'any', 'some', 'another', 'no', 'one',
   'bulk', 'mass', 'batch', 'data', 'manual', 'automatic', 'automated',
   'nightly', 'daily', 'weekly', 'monthly', 'initial', 'full', 'partial',
-  'failed', 'successful', 'new', 'existing',
+  'failed', 'successful', 'new', 'existing'
+]);
+
+// Positional modifiers are noun signals only mid-sentence ("the first import
+// failed"). Sentence-initial they are imperative adverbs — "First import
+// numpy into the notebook" is a real statement and must keep firing.
+const importPositionalSignals = new Set([
   'first', 'second', 'last', 'next', 'previous'
+]);
+
+// Language names preceding "import" introduce a real statement ("For Python
+// import pdfplumber", "In Swift import Foundation"), unlike attributive
+// proper nouns ("the Salesforce import connector").
+const importLanguageNames = new Set([
+  'Python', 'Swift', 'JavaScript', 'TypeScript', 'Java', 'Kotlin', 'Rust',
+  'Go', 'Ruby', 'PHP', 'Haskell', 'Scala', 'Perl', 'Julia', 'Dart',
+  'Elixir', 'Lua', 'Clojure', 'Node'
 ]);
 
 /**
@@ -80,11 +98,17 @@ const importNounSignals = new Set([
  * 1. The word after `import` is a common English word, not a plausible
  *    module identifier.
  * 2. `import` is preceded by a determiner or noun-marking modifier
- *    ("the import …", "bulk import …").
+ *    ("the import …", "bulk import …"), or a mid-sentence positional
+ *    modifier ("the first import failed"). Sentence-initial positionals
+ *    are imperative ("First import numpy") and keep firing.
  * 3. `import` is preceded by a capitalized word that is not the start of
- *    its sentence — a mid-sentence proper noun used attributively
- *    ("…the Salesforce import connector"). Sentence-initial verbs like
- *    "Add import pdfplumber" or "Use import os" keep firing.
+ *    its sentence or clause — a proper noun used attributively
+ *    ("…the Salesforce import connector"). Language names ("For Python
+ *    import pdfplumber") and sentence-initial verbs ("Add import
+ *    pdfplumber") keep firing.
+ *
+ * A `from X import Y` clause always counts as a real statement, whatever
+ * the object word.
  *
  * @param {string} line - Line being evaluated.
  * @param {number} start - Start index of the `import …` match.
@@ -92,30 +116,47 @@ const importNounSignals = new Set([
  * @returns {boolean} True when the match is prose, not a code statement.
  */
 export function isProseImportUsage(line, start, match) {
+  const beforeImport = line.slice(0, start);
+
+  // "from sklearn import pipeline" is a Python statement regardless of how
+  // English the imported name looks.
+  if (/\bfrom\s+[\w.]+\s+$/.test(beforeImport)) {
+    return false;
+  }
+
   const objectWord = match.replace(/^import\s+/, '');
   if (importProseObjects.has(objectWord)) {
     return true;
   }
 
-  const beforeImport = line.slice(0, start);
-  const precedingWordMatch = /([A-Za-z][\w'’-]*)\s+$/.exec(beforeImport);
+  // Trailing emphasis markers are skipped so "**Bulk** import parser"
+  // still exposes the "bulk" signal.
+  const precedingWordMatch = /([A-Za-z][\w'’-]*)[*_]{0,3}\s+$/.exec(beforeImport);
   if (!precedingWordMatch) {
     return false;
   }
 
   const precedingWord = precedingWordMatch[1];
-  if (importNounSignals.has(precedingWord.toLowerCase())) {
+  const beforeWord = beforeImport.slice(0, precedingWordMatch.index);
+  // Sentence- or clause-initial: only whitespace/list markers before the
+  // word, or the word follows boundary punctuation.
+  const wordIsSentenceInitial =
+    /^\s*(?:(?:[-*+>]|\d+[.)])\s+)*$/.test(beforeWord) ||
+    /[.!?:;]["')\]]*\s+$/.test(beforeWord);
+
+  const precedingLower = precedingWord.toLowerCase();
+  if (importNounSignals.has(precedingLower)) {
+    return true;
+  }
+  if (importPositionalSignals.has(precedingLower) && !wordIsSentenceInitial) {
     return true;
   }
 
   if (/^[A-Z]/.test(precedingWord)) {
-    const beforeWord = beforeImport.slice(0, precedingWordMatch.index);
-    // Sentence-initial: only whitespace/list markers before the word, or the
-    // word follows sentence-boundary punctuation.
-    const sentenceInitial =
-      /^\s*(?:(?:[-*+>]|\d+[.)])\s+)*$/.test(beforeWord) ||
-      /[.!?:;,]["')\]]*\s+$/.test(beforeWord);
-    if (!sentenceInitial) {
+    if (importLanguageNames.has(precedingWord)) {
+      return false;
+    }
+    if (!wordIsSentenceInitial) {
       return true;
     }
   }
@@ -485,18 +526,26 @@ export function isLikelyFilePath(str) {
   // "auto-renewal"), so prose alternative lists like "grades/stars/half-stars"
   // or "title/id/year" are not treated as paths (#319). Path signals that
   // override the bail-out: an absolute/relative prefix, or a "to" placeholder
-  // segment ("path/to/folder"). A known-directory first segment deliberately
-  // does not override: prose enumerations like "models/views/controllers"
-  // start with directory-like words (see the passing fixture).
+  // segment ("path/to/folder"). Additionally, the broadened word shapes
+  // (hyphenated or 2-letter segments) do not exempt a run that also contains
+  // a known directory name — "my-app/src/components" and "dist/es/lib" stay
+  // paths — while runs of plain 3+-letter words keep the pre-existing prose
+  // treatment even when directory-like ("models/views/controllers", see the
+  // passing fixture).
   const nonEmptySegments = segments.filter(s => s !== '');
   const isAbsoluteOrRelative = /^[/~.]/.test(str);
   const hasPlaceholderSegment = nonEmptySegments.includes('to');
+  const allPlainWords = nonEmptySegments.every(s => /^[a-zA-Z]{3,}$/.test(s));
+  const hasKnownDirectorySegment = nonEmptySegments.some(
+    s => knownDirectoryPrefixes.includes(s.toLowerCase())
+  );
   if (
     !isAbsoluteOrRelative &&
     !hasPlaceholderSegment &&
     nonEmptySegments.length >= 3 &&
     nonEmptySegments.every(s => /^[a-zA-Z]{2,}(?:-[a-zA-Z]+)*$/.test(s)) &&
-    !nonEmptySegments.some(s => /\.\w+$/.test(s))
+    !nonEmptySegments.some(s => /\.\w+$/.test(s)) &&
+    (allPlainWords || !hasKnownDirectorySegment)
   ) {
     return false;
   }

--- a/tests/features/backtick-bce001-false-positives.test.js
+++ b/tests/features/backtick-bce001-false-positives.test.js
@@ -4,6 +4,7 @@
  * - #192: scientific/measurement terms (pH, fMRI, mTOR)
  * - #194: bare URLs flagged as file/directory paths
  * - #196: ellipsis-joined prose words (only...but)
+ * - #319: prose phrases misread as imports, paths, and flags
  */
 import { describe, test, expect } from "@jest/globals";
 import { lint } from "markdownlint/promise";
@@ -242,5 +243,109 @@ describe("BCE001 import-homograph prose (#236)", () => {
       "Run fill_form.py to populate the document.",
     );
     expect(violations.length).toBeGreaterThan(0);
+  });
+});
+
+describe("BCE001 noun-phrase 'import' in prose (#319)", () => {
+  test("does not flag 'import polish' after a product name", async () => {
+    const violations = await getBCE001Violations(
+      "Instagram import polish lands in this release.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag 'import success' after a determiner", async () => {
+    const violations = await getBCE001Violations(
+      "Improved the import success screen.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag 'import safety' as a bare noun compound", async () => {
+    const violations = await getBCE001Violations(
+      "Shipped import safety fixes for large libraries.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag import preceded by a determiner regardless of the following word", async () => {
+    const violations = await getBCE001Violations(
+      "The import parser opens the picker.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag import preceded by a mid-sentence proper noun", async () => {
+    const violations = await getBCE001Violations(
+      "Rebuilt the Salesforce import connector this week.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("still flags a standalone import statement", async () => {
+    const violations = await getBCE001Violations("import Foundation");
+    const importErrors = violations.filter(
+      (v) => v.errorContext === "import Foundation",
+    );
+    expect(importErrors.length).toBeGreaterThan(0);
+  });
+
+  test("still flags a mid-sentence module import", async () => {
+    const violations = await getBCE001Violations(
+      "Add import pdfplumber at the top of the script.",
+    );
+    const importErrors = violations.filter(
+      (v) => v.errorContext === "import pdfplumber",
+    );
+    expect(importErrors.length).toBeGreaterThan(0);
+  });
+});
+
+describe("BCE001 prose slash-lists are not paths (#319)", () => {
+  test("does not flag a slash list of plural nouns", async () => {
+    const violations = await getBCE001Violations(
+      "display modes: grades/stars/half-stars",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag a slash list with a short segment", async () => {
+    const violations = await getBCE001Violations(
+      "Search by title/id/year in the library.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag a slash list of hyphenated compounds", async () => {
+    const violations = await getBCE001Violations(
+      "Handle auto-renewal/cancellation/refund flows.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("still flags a real path with a file extension", async () => {
+    const violations = await getBCE001Violations(
+      "See src/utils/foo.ts for details.",
+    );
+    expect(violations.length).toBeGreaterThan(0);
+  });
+});
+
+describe("BCE001 hyphenated compound after a code span (#319 regression)", () => {
+  test("does not flag '-returning' after a backticked identifier", async () => {
+    const violations = await getBCE001Violations(
+      "`Binding`-returning methods are now documented.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("still flags a genuine CLI flag", async () => {
+    const violations = await getBCE001Violations(
+      "Pass the --verbose option to see details.",
+    );
+    const flagErrors = violations.filter(
+      (v) => v.errorContext === "--verbose",
+    );
+    expect(flagErrors.length).toBeGreaterThan(0);
   });
 });

--- a/tests/features/backtick-bce001-false-positives.test.js
+++ b/tests/features/backtick-bce001-false-positives.test.js
@@ -358,6 +358,44 @@ describe("BCE001 noun-phrase 'import' in prose (#319)", () => {
     );
     expect(violations).toHaveLength(0);
   });
+
+  test("does not flag 'from <determiner> import' English phrases", async () => {
+    const violations = await getBCE001Violations(
+      "Recover photos from the import screen.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag 'from your import' possessive phrases", async () => {
+    const violations = await getBCE001Violations(
+      "Load defaults from your import profile.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag 'from each import' quantified phrases", async () => {
+    const violations = await getBCE001Violations(
+      "Data flows from each import batch into the warehouse.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag a language name used attributively after a verb", async () => {
+    const violations = await getBCE001Violations(
+      "Improved Python import resolution in the bundler.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("still flags a language-name import after a preposition", async () => {
+    const violations = await getBCE001Violations(
+      "In Swift import Foundation loads the framework.",
+    );
+    const importErrors = violations.filter(
+      (v) => v.errorContext === "import Foundation",
+    );
+    expect(importErrors.length).toBeGreaterThan(0);
+  });
 });
 
 describe("BCE001 prose slash-lists are not paths (#319)", () => {

--- a/tests/features/backtick-bce001-false-positives.test.js
+++ b/tests/features/backtick-bce001-false-positives.test.js
@@ -299,6 +299,65 @@ describe("BCE001 noun-phrase 'import' in prose (#319)", () => {
     );
     expect(importErrors.length).toBeGreaterThan(0);
   });
+
+  test("still flags a bare stdlib import whose name is an English noun", async () => {
+    const violations = await getBCE001Violations("import warnings");
+    const importErrors = violations.filter(
+      (v) => v.errorContext === "import warnings",
+    );
+    expect(importErrors.length).toBeGreaterThan(0);
+  });
+
+  test("still flags a from-clause import with an English object word", async () => {
+    const violations = await getBCE001Violations(
+      "Use from sklearn import pipeline in the notebook.",
+    );
+    const importErrors = violations.filter(
+      (v) => v.errorContext === "import pipeline",
+    );
+    expect(importErrors.length).toBeGreaterThan(0);
+  });
+
+  test("still flags a sentence-initial imperative with an ordinal", async () => {
+    const violations = await getBCE001Violations(
+      "First import numpy into the notebook.",
+    );
+    const importErrors = violations.filter(
+      (v) => v.errorContext === "import numpy",
+    );
+    expect(importErrors.length).toBeGreaterThan(0);
+  });
+
+  test("does not flag an ordinal-preceded noun import mid-sentence", async () => {
+    const violations = await getBCE001Violations(
+      "Retry when the first import attempt stalls.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("still flags an import preceded by a language name", async () => {
+    const violations = await getBCE001Violations(
+      "For Python import pdfplumber at the top.",
+    );
+    const importErrors = violations.filter(
+      (v) => v.errorContext === "import pdfplumber",
+    );
+    expect(importErrors.length).toBeGreaterThan(0);
+  });
+
+  test("does not flag noun usage after an emphasized modifier", async () => {
+    const violations = await getBCE001Violations(
+      "**Bulk** import parser now streams rows.",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("does not flag a clause-initial proper noun compound", async () => {
+    const violations = await getBCE001Violations(
+      "Once enabled, Shopify import mapping runs automatically.",
+    );
+    expect(violations).toHaveLength(0);
+  });
 });
 
 describe("BCE001 prose slash-lists are not paths (#319)", () => {
@@ -331,7 +390,7 @@ describe("BCE001 prose slash-lists are not paths (#319)", () => {
   });
 });
 
-describe("BCE001 hyphenated compound after a code span (#319 regression)", () => {
+describe("BCE001 hyphenated compound after a code span (#319; behavior from #301/#306)", () => {
   test("does not flag '-returning' after a backticked identifier", async () => {
     const violations = await getBCE001Violations(
       "`Binding`-returning methods are now documented.",

--- a/tests/unit/backtick-path-detection.test.js
+++ b/tests/unit/backtick-path-detection.test.js
@@ -131,6 +131,14 @@ describe("backtick-code-elements path detection", () => {
     test("should still flag 'path/to/folder' placeholder paths", async () => {
       await testPattern("Open path/to/folder/ for logs", true);
     });
+
+    test("should still flag hyphenated paths containing a known directory", async () => {
+      await testPattern("Check my-app/src/components for the layout code", true);
+    });
+
+    test("should still flag short-segment paths containing a known directory", async () => {
+      await testPattern("The generated files live in dist/es/lib after the build", true);
+    });
   });
 
   describe("common option patterns", () => {

--- a/tests/unit/backtick-path-detection.test.js
+++ b/tests/unit/backtick-path-detection.test.js
@@ -139,6 +139,13 @@ describe("backtick-code-elements path detection", () => {
     test("should still flag short-segment paths containing a known directory", async () => {
       await testPattern("The generated files live in dist/es/lib after the build", true);
     });
+
+    // Accepted trade-off: an extensionless kebab-case run with no known
+    // directory segment reads as a prose alternative list, so a real path
+    // of that shape goes unflagged rather than prose being flagged.
+    test("should not flag kebab-case runs lacking path evidence", async () => {
+      await testPattern("Rename my-widget/cool-icon/nice-thing before shipping", false);
+    });
   });
 
   describe("common option patterns", () => {

--- a/tests/unit/backtick-path-detection.test.js
+++ b/tests/unit/backtick-path-detection.test.js
@@ -111,6 +111,28 @@ describe("backtick-code-elements path detection", () => {
     });
   });
 
+  describe("prose slash-lists (issue #319)", () => {
+    test("should not flag plural-noun lists", async () => {
+      await testPattern("display modes: grades/stars/half-stars", false);
+    });
+
+    test("should not flag lists containing a two-letter segment", async () => {
+      await testPattern("Search by title/id/year in the library", false);
+    });
+
+    test("should not flag hyphenated compound lists", async () => {
+      await testPattern("Handle auto-renewal/cancellation/refund flows", false);
+    });
+
+    test("should still flag paths ending in a file extension", async () => {
+      await testPattern("Open src/utils/foo.ts to edit", true);
+    });
+
+    test("should still flag 'path/to/folder' placeholder paths", async () => {
+      await testPattern("Open path/to/folder/ for logs", true);
+    });
+  });
+
   describe("common option patterns", () => {
     test("should not flag pass/fail", async () => {
       await testPattern("The pass/fail criteria are documented", false);


### PR DESCRIPTION
## Summary

Brief description of the changes and the problem being solved:

- BCE001 flagged ordinary English prose as code elements in three classes (#319): noun-phrase "import" ("Instagram import polish", "the import success screen"), prose slash-lists ("grades/stars/half-stars", "title/id/year", "auto-renewal/cancellation/refund"), and hyphenated compounds after a code span (`` `Binding` ``-returning).
- Import detection: the giant negative-lookahead exclusion list moved out of the regex into a maintainable `importProseObjects` set in `src/rules/backtick/detection-helpers.js`, and a new `isProseImportUsage` helper adds context checks — a common-English object word, a preceding determiner/noun modifier ("the import …", "bulk import …", "**Bulk** import …"), a mid-sentence positional modifier ("the first import attempt"), or a non-clause-initial proper noun ("…the Salesforce import connector") marks noun usage. Genuine statements keep firing: `import Foundation`, mid-sentence `import pdfplumber`, bare stdlib names ("import warnings"), `from X import Y` clauses, sentence-initial imperatives ("First import numpy"), and language-name contexts ("For Python import pdfplumber").
- Path detection: the 3+ segment natural-language bail-out in `isLikelyFilePath` now accepts two-letter and hyphen-joined word shapes, so prose alternative lists are not paths. Real-path signals still win: a `to` placeholder segment (`path/to/folder`), an absolute/relative prefix, or a known directory name mixed with hyphenated/short segments (`my-app/src/components`, `dist/es/lib`). Runs of plain 3+-letter words keep the pre-existing prose treatment (`models/views/controllers`).
- The `-returning` flag false positive was already fixed by #301/#306; this PR pins it with regression tests.
- A subagent code review of the first commit surfaced heuristic regressions (real module names in the prose set, ordinals defeating tutorial imperatives, language names swallowed, real paths unflagged); the second commit fixes all of them with pinned tests.

## Test plan

### Automated testing

- [x] Unit tests pass (`tests/unit/backtick-path-detection.test.js`, +8 cases)
- [x] Integration tests pass
- [x] Full test suite passes (1802 passed, 9 skipped)
- [x] All quality checks pass (`npm run validate`: ESLint + full suite; `npm run lint:md`: 0 errors on 26 files)

### Manual testing

- [x] Tested with representative data — all issue #319 example sentences verified clean, all true-positive guards verified still firing (24-case empirical battery run against the branch)
- [x] Edge cases and error conditions verified — sentence-initial verbs and ordinals, determiner/emphasis-preceded imports, `from X import Y`, language names, clause-initial proper nouns, placeholder paths, extension-bearing and mixed-evidence paths
- [x] Performance impact assessed — the import regex is now simpler (no 100-alternative lookahead); the set lookups run only on candidate matches

### Test coverage

- [x] New functionality has comprehensive tests (33 new test cases across feature and unit layers)
- [x] Test coverage maintained or improved
- [x] Tests follow behavioral naming
- [x] Tests focus on meaningful behavior, not implementation details

## Breaking changes

- None. Rule names, config options, and public exports are unchanged. Consumers may see fewer BCE001 findings on prose; `npm run validate:external` reports an identical violation total (320) on the fixture corpus before and after.

## Performance and reliability

- [x] Memory usage impact considered — small static `Set`s replace a monolithic regex alternation
- [x] Retry patterns and error handling implemented where appropriate — n/a, pure detection logic
- [x] Logging added for debugging and monitoring — n/a, existing rule reporting unchanged

## Code quality

- [x] Type annotations added for new code (JSDoc on `isProseImportUsage`)
- [x] Error handling implemented with clear messages — existing contextual error messages unchanged
- [x] Functions maintain single responsibility

## Documentation

- [x] Docstrings added for new public functions
- [x] API documentation updated if public APIs added or changed — verified n/a: no public API added or changed (rule names, config options, and exports unchanged)
- [x] README updated if public-facing behavior changed — verified n/a for README; user-facing fix documented in the `CHANGELOG.md` Unreleased section

## Conventional commit compliance

- [x] PR title uses solution-oriented summary (not conventional commit format)
- [x] Individual commits follow conventional commit format: `fix(bce001): …`
- [x] Scope indicates module/component affected
- [x] Semantic versioning impact: **PATCH**

## Additional context

- Closes #319
- All five acceptance criteria from the issue are covered by tests: the three GIVEN/WHEN/THEN prose examples lint clean, genuine `import Foundation` / `src/utils/foo.ts` still fire, and the existing rule suites pass unchanged.
- Reviewer focus: the word sets in `src/rules/backtick/detection-helpers.js` — real module names are deliberately kept out of `importProseObjects` (`warnings`, `views`, `tasks`, `retry`), and the path bail-out's mixed-evidence rule (`allPlainWords || !hasKnownDirectorySegment`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuDnA6bXgS8mCjm9DXXrn9
