### PR TITLE
Fix swapped GHSA advisory IDs in the 4.1.0 dev log

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -12,7 +12,7 @@ Engineering record — refactors, internal tooling, build changes, ADRs, depende
 
 Dependency-advisory hygiene, preset guard, and CI cleanup behind the rule fixes.
 
-- Patched the markdown-it and js-yaml advisories (GHSA-h67p-54hq-rp68, GHSA-6v5v-wf23-fmfq) via lockfile regen plus `overrides` for markdownlint-cli2 nested copies and istanbul's js-yaml — transitive/dev only, no user-facing exposure, so kept out of CHANGELOG
+- Patched the markdown-it and js-yaml advisories (GHSA-6v5v-wf23-fmfq, GHSA-h67p-54hq-rp68) via lockfile regen plus `overrides` for markdownlint-cli2 nested copies and istanbul's js-yaml — transitive/dev only, no user-facing exposure, so kept out of CHANGELOG
 - Removed the pr-checklist-gate Gitea workflow — the repo is GitHub-hosted, so the Gitea-only gate never ran and was dead config
 - Added a regression test asserting MD013 stays disabled across presets, locking in the line-length policy against accidental re-enable
 - Updated dev tooling — prettier ^3.9.4, eslint ^10.6.0, lint-staged v17 — and ran lockfile maintenance


### PR DESCRIPTION
## Summary

- The `[4.1.0]` DEVLOG entry lists the two patched security advisories in the wrong order relative to the "markdown-it and js-yaml" package order: GHSA-6v5v-wf23-fmfq is the markdown-it smartquotes DoS (CVE-2026-48988) and GHSA-h67p-54hq-rp68 is the js-yaml merge-key DoS (CVE-2026-53550).
- Swaps the two IDs so each advisory is attributed to the right package; verified against the GitHub Advisory Database (`gh api /advisories/<id>`).
- Caught independently by both dependency reviewers during the Renovate PR batch review on 2026-07-16.

## Test plan

- [x] `npm run lint:md` passes (0 errors, 26 files)
- [x] Both advisory-to-package mappings verified via the GitHub Advisory Database

## Breaking changes

None — documentation-only change.