### PR TITLE
Resolve percent-encoded link paths in DL001

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ User-facing changes — new capabilities, behavior changes, fixes that affected 
 
 ## [Unreleased]
 
+### Fixed
+
+- DL001 now resolves percent-encoded link paths. A link whose target uses URL-encoded spaces — `[Guide](How%20to%20access.md)` — is decoded before the existence check, so pointing at a file whose name contains spaces no longer reports a false "does not exist." Malformed escapes fall back to the raw path rather than crashing the rule.
+
 ---
 
 ## [4.1.1] - 2026-07-16

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -4,6 +4,8 @@ Engineering record — refactors, internal tooling, build changes, ADRs, depende
 
 ## [Unreleased]
 
+- Percent-decode happens once, right after the anchor split, in `no-dead-internal-links.js`. Decoding before ignore-matching, placeholder checks, and disk resolution means every downstream consumer sees the real filename; the `decodeLinkPath` helper wraps `decodeURIComponent` in a try/catch so a bare `%` degrades to the raw path instead of throwing out of the lint pass.
+
 ---
 
 ## [4.1.1] - 2026-07-16

--- a/src/rules/no-dead-internal-links.js
+++ b/src/rules/no-dead-internal-links.js
@@ -113,6 +113,23 @@ function resolvePath(currentFile, linkPath) {
   return path.resolve(dir, linkPath);
 }
 
+/**
+ * Percent-decode a link path so URL-encoded destinations resolve against real
+ * filenames on disk — e.g. "How%20to%20access.md" -> "How to access.md".
+ * Returns the input unchanged when it carries a malformed escape (a bare "%"),
+ * which decodeURIComponent rejects, so the link is still checked rather than
+ * silently skipped.
+ * @param {string} linkPath - The raw link path, before resolution
+ * @returns {string} The decoded path, or the original on a malformed escape
+ */
+function decodeLinkPath(linkPath) {
+  try {
+    return decodeURIComponent(linkPath);
+  } catch {
+    return linkPath;
+  }
+}
+
 // Cache resolved repo roots per starting directory to avoid repeated upward
 // filesystem walks within a single lint run.
 const repoRootCache = new Map(); // startDir -> string|null
@@ -432,8 +449,10 @@ function noDeadInternalLinks(params, onError) {
         continue;
       }
       
-      // Parse the link URL to separate file path and anchor
-      const [filePath, anchor] = linkUrl.split('#');
+      // Parse the link URL to separate file path and anchor, then percent-decode
+      // the path so URL-encoded spaces and other escapes resolve to real files.
+      const [rawFilePath, anchor] = linkUrl.split('#');
+      const filePath = decodeLinkPath(rawFilePath);
 
       if (filePath) {
         // Check if this path should be ignored

--- a/tests/features/no-dead-internal-links.test.js
+++ b/tests/features/no-dead-internal-links.test.js
@@ -158,6 +158,30 @@ This is [a link to non-existent section](#missing-section).
       expect(errors[1].detail).toContain('Link target "subdirectory/missing.md" does not exist');
     });
 
+    test('resolves percent-encoded spaces to real filenames', () => {
+      const markdown = `
+[Encoded space, target exists](spaced%20file.md)
+[Encoded space, target missing](missing%20file.md)
+`;
+
+      const errors = runRuleWithContent(markdown, testFile);
+
+      // The encoded link to "spaced file.md" resolves; only the missing one
+      // errors, and it reports the decoded target name.
+      expect(errors).toHaveLength(1);
+      expect(errors[0].detail).toContain('Link target "missing file.md" does not exist');
+    });
+
+    test('does not throw on a malformed percent escape', () => {
+      const markdown = '[Bad escape](bad%ZZname.md)\n';
+
+      const errors = runRuleWithContent(markdown, testFile);
+
+      // Malformed escapes fall back to the raw path rather than crashing.
+      expect(errors).toHaveLength(1);
+      expect(errors[0].detail).toContain('Link target "bad%ZZname.md" does not exist');
+    });
+
     test('validates heading anchors in other files', () => {
       const markdown = `
 [Valid heading](existing-file.md#section-one)

--- a/tests/fixtures/no-dead-internal-links/spaced file.md
+++ b/tests/fixtures/no-dead-internal-links/spaced file.md
@@ -1,0 +1,4 @@
+# Spaced file
+
+A fixture whose filename contains a space, used to verify that
+percent-encoded link paths (`spaced%20file.md`) resolve to it.


### PR DESCRIPTION
## Summary

- DL001 (`no-dead-internal-links`) resolved link targets literally, so a link whose path used URL-encoded spaces — `[Guide](How%20to%20access.md)` — was looked up with the `%20` still in it and reported as a dead link even when the file existed.
- The rule now percent-decodes the link path before the existence check, ignore-matching, and placeholder checks, so encoded destinations resolve to the real filename.
- A malformed escape (a bare `%`) falls back to the raw path instead of throwing `decodeURIComponent` out of the lint pass.

## Test plan

### Automated testing
- [x] `npm test` passes (1804 passed, 9 skipped)
- [x] New regression tests cover encoded-space resolution, a still-missing encoded target, and the malformed-escape guard
- [x] `npm run lint` clean

### Test coverage
- [x] New behavior has tests

## Breaking changes

None — repositories that link to files with spaces will see fewer false DL001 findings.

## Documentation

- [x] CHANGELOG and DEVLOG updated